### PR TITLE
Update MCP server to use components URL structure and enhance reference section support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Livewire Flux MCP
 
-An MCP (Model Context Protocol) server that provides access to Livewire Flux Components documentation from [fluxui.dev](https://fluxui.dev/docs/). This server allows AI assistants to fetch and search through Flux component documentation on demand.
+An MCP (Model Context Protocol) server that provides access to Livewire Flux Components documentation from [fluxui.dev](https://fluxui.dev/components/). This server allows AI assistants to fetch and search through Flux component documentation on demand.
 
 ## Support Me
 
@@ -19,7 +19,8 @@ You can even choose 😃:
 
 This MCP server scrapes and provides structured access to the Livewire Flux documentation, enabling AI assistants to:
 
-- Fetch documentation for specific Flux components
+- Fetch documentation for specific Flux components from `https://fluxui.dev/components/`
+- Access component reference sections with API details, props, and usage patterns
 - Search through component documentation content
 - List all available Flux components
 - Access up-to-date documentation directly from the official Flux website
@@ -96,10 +97,13 @@ The server provides two MCP tools:
 1. **`fetch_flux_docs`** - Fetches documentation for components
    - `component` (optional): Specific component name to fetch docs for
    - `search` (optional): Search term to filter content
+   - Automatically includes component reference sections when available
+   - Fetches from `https://fluxui.dev/components/{component}`
 
 2. **`list_flux_components`** - Lists all available Flux components
    - No parameters required
-   - Returns a list of components with their documentation paths
+   - Returns components with `https://fluxui.dev/components/` prefix
+   - Provides component names and their documentation paths
 
 ### Example Usage
 
@@ -109,7 +113,7 @@ Once the MCP server is running, AI assistants can use it to:
 - Search for content: "Find all components related to forms"
 - List available components: "What Flux components are available?"
 
-The server automatically fetches the latest documentation from fluxui.dev and presents it in a structured format for easy consumption by AI assistants.
+The server automatically fetches the latest documentation from fluxui.dev/components and presents it in a structured format for easy consumption by AI assistants. When fetching component documentation, it includes both the main content and the reference section with detailed API information.
 
 ## Integration with Claude Code
 


### PR DESCRIPTION
## Summary
- Update `fetch_flux_docs` to use `https://fluxui.dev/components/` instead of `/docs/`
- Add automatic extraction and integration of component reference sections for better API documentation
- Update `list_flux_components` to filter links with `components/` prefix
- Update README.md to reflect new URL structure and enhanced functionality

## Changes Made
- **fetch_flux_docs**: Now fetches from `https://fluxui.dev/components/{component}` and automatically includes reference sections
- **list_flux_components**: Filters links to only include those with `https://fluxui.dev/components/` prefix
- **Reference section integration**: Extracts and combines reference sections with main documentation for comprehensive component understanding
- **README updates**: Updated documentation to reflect new URL structure and enhanced capabilities

## Benefits
- Better alignment with the actual Flux documentation structure
- Enhanced LLM understanding through integrated reference sections containing API details, props, and usage patterns
- More accurate component discovery and documentation retrieval

🤖 Generated with [Claude Code](https://claude.ai/code)