### PR TITLE
Add changelog with GitHub releases and project templates

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,10 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
-      "WebFetch(domain:docs.anthropic.com)",
-      "Bash(gh repo create:*)",
-      "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "WebFetch(domain:docs.anthropic.com)"
     ],
     "deny": []
   }

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,1 @@
-# These are supported funding model platforms
-
-github: lemaur # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+github: lemaur

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Report an Issue or Bug with the Package
+title: "[Bug]: "
+labels: ["bug"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              We're sorry to hear you have a problem. Can you help us solve it by providing the following details.
+    - type: textarea
+      id: what-happened
+      attributes:
+          label: What happened?
+          description: What did you expect to happen?
+          placeholder: I cannot currently do X thing because when I do, it breaks X thing.
+      validations:
+          required: true
+    - type: textarea
+      id: how-to-reproduce
+      attributes:
+          label: How to reproduce the bug
+          description: How did this occur, please add any config values used and provide a set of reliable steps if possible.
+          placeholder: When I do X I see Y.
+      validations:
+          required: true
+    - type: input
+      id: package-version
+      attributes:
+          label: Package Version
+          description: What version of our Package are you running? Please be as specific as possible
+          placeholder: 2.0.0
+      validations:
+          required: true
+    - type: input
+      id: php-version
+      attributes:
+          label: PHP Version
+          description: What version of PHP are you running? Please be as specific as possible
+          placeholder: 8.2.0
+      validations:
+          required: true
+    - type: dropdown
+      id: operating-systems
+      attributes:
+        label: Which operating systems does with happen with?
+        description: You may select more than one.
+        multiple: true
+        options:
+        - macOS
+        - Windows
+        - Linux
+    - type: textarea
+      id: notes
+      attributes:
+          label: Notes
+          description: Use this field to provide any other notes that you feel might be relevant to the issue.
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/leMaur/livewire-flux-mcp/discussions/new?category=q-a
+    about: Ask the community for help
+  - name: Request a feature
+    url: https://github.com/leMaur/livewire-flux-mcp/discussions/new?category=ideas
+    about: Share ideas for new features
+  - name: Report a security issue
+    url: https://github.com/leMaur/livewire-flux-mcp/security/policy
+    about: Learn how to notify us for sensitive bugs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: dependabot-auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2.0.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge Dependabot PRs for semver-minor updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Auto-merge Dependabot PRs for semver-patch updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,32 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to `livewire-flux-mcp` will be documented in this file.
+
+## [1.0.1] - 2025-08-01
+
+**Full Changelog**: https://github.com/leMaur/livewire-flux-mcp/compare/1.0.0...1.0.1
+
+## [1.0.0] - 2025-08-01
+
+Initial release
+
+**Full Changelog**: https://github.com/leMaur/livewire-flux-mcp/commits/1.0.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+If you discover any security related issues, please email hello@lemaur.me instead of using the issue tracker.


### PR DESCRIPTION
## Summary
- Add CHANGELOG.md with releases 1.0.1 and 1.0.0 fetched from GitHub releases
- Add GitHub issue templates for better bug reporting
- Add GitHub workflow configurations including dependabot auto-merge and changelog updates
- Add security policy and funding configuration
- Update project documentation and settings

## Test plan
- [x] Verify CHANGELOG.md format and content
- [x] Check GitHub templates render correctly
- [x] Confirm workflow files are valid YAML
- [x] Review security and funding configurations

🤖 Generated with [Claude Code](https://claude.ai/code)