### PR TITLE
test+ci: real tests against index.js, gated by new Test workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,6 +18,15 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Wait for Test workflow to succeed
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: test
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+          allowed-conclusions: success
+
       - name: Auto-merge Dependabot PRs for semver-minor updates
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,14 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
 
       - name: Get latest tag
         id: get-latest-tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/index.js
+++ b/index.js
@@ -6,10 +6,77 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import fetch from 'node-fetch';
+import defaultFetch from 'node-fetch';
 import * as cheerio from 'cheerio';
+import { readFileSync, realpathSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+import process from 'node:process';
 
-class SimpleCache {
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(
+  readFileSync(join(__dirname, 'package.json'), 'utf-8')
+);
+
+export const TOOL_DEFINITIONS = [
+  {
+    name: 'fetch_flux_docs',
+    description: 'Fetch documentation for Livewire Flux components or layouts from fluxui.dev',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        component: {
+          type: 'string',
+          description: 'The component name or path to fetch documentation for (optional)',
+        },
+        layout: {
+          type: 'string',
+          description: 'The layout name to fetch documentation for (e.g., "header", "sidebar") (optional)',
+        },
+        search: {
+          type: 'string',
+          description: 'Search term to find specific documentation (optional)',
+        },
+      },
+    },
+  },
+  {
+    name: 'list_flux_components',
+    description: 'List all available Flux components from the documentation',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'list_flux_layouts',
+    description: 'List all available Flux layouts from the documentation',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'list_flux_component_icons',
+    description: 'List all available Heroicons for use with flux:icon component, with variants and usage examples',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        variant: {
+          type: 'string',
+          enum: ['outline', 'solid', 'mini', 'micro'],
+          description: 'Filter icons by variant (optional)',
+        },
+        search: {
+          type: 'string',
+          description: 'Search term to filter icon names (optional)',
+        },
+      },
+    },
+  },
+];
+
+export class SimpleCache {
   constructor(ttlMs = 24 * 60 * 60 * 1000) { // 24 hours default
     this.cache = new Map();
     this.ttl = ttlMs;
@@ -18,12 +85,12 @@ class SimpleCache {
   get(key) {
     const entry = this.cache.get(key);
     if (!entry) return null;
-    
+
     if (Date.now() - entry.timestamp > this.ttl) {
       this.cache.delete(key);
       return null;
     }
-    
+
     return entry.data;
   }
 
@@ -39,12 +106,12 @@ class SimpleCache {
   }
 }
 
-class FluxDocumentationServer {
-  constructor() {
+export class FluxDocumentationServer {
+  constructor({ fetch: fetchImpl = defaultFetch } = {}) {
     this.server = new Server(
       {
         name: 'livewire-flux-mcp',
-        version: '1.0.0',
+        version: pkg.version,
       },
       {
         capabilities: {
@@ -53,71 +120,14 @@ class FluxDocumentationServer {
       }
     );
 
+    this.fetch = fetchImpl;
     this.cache = new SimpleCache();
     this.setupToolHandlers();
   }
 
   setupToolHandlers() {
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-      return {
-        tools: [
-          {
-            name: 'fetch_flux_docs',
-            description: 'Fetch documentation for Livewire Flux components or layouts from fluxui.dev',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                component: {
-                  type: 'string',
-                  description: 'The component name or path to fetch documentation for (optional)',
-                },
-                layout: {
-                  type: 'string',
-                  description: 'The layout name to fetch documentation for (e.g., "header", "sidebar") (optional)',
-                },
-                search: {
-                  type: 'string',
-                  description: 'Search term to find specific documentation (optional)',
-                },
-              },
-            },
-          },
-          {
-            name: 'list_flux_components',
-            description: 'List all available Flux components from the documentation',
-            inputSchema: {
-              type: 'object',
-              properties: {},
-            },
-          },
-          {
-            name: 'list_flux_layouts',
-            description: 'List all available Flux layouts from the documentation',
-            inputSchema: {
-              type: 'object',
-              properties: {},
-            },
-          },
-          {
-            name: 'list_flux_component_icons',
-            description: 'List all available Heroicons for use with flux:icon component, with variants and usage examples',
-            inputSchema: {
-              type: 'object',
-              properties: {
-                variant: {
-                  type: 'string',
-                  enum: ['outline', 'solid', 'mini', 'micro'],
-                  description: 'Filter icons by variant (optional)',
-                },
-                search: {
-                  type: 'string',
-                  description: 'Search term to filter icon names (optional)',
-                },
-              },
-            },
-          },
-        ],
-      };
+      return { tools: TOOL_DEFINITIONS };
     });
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -152,7 +162,7 @@ class FluxDocumentationServer {
   async fetchFluxDocs(component, layout, search) {
     try {
       let url;
-      
+
       if (layout) {
         // Handle layout requests
         url = `https://fluxui.dev/layouts/${layout}`;
@@ -160,7 +170,7 @@ class FluxDocumentationServer {
         // Handle component requests (existing logic)
         const baseUrl = 'https://fluxui.dev/components';
         url = baseUrl;
-        
+
         if (component) {
           url = `${baseUrl}/${component}`;
         }
@@ -168,14 +178,14 @@ class FluxDocumentationServer {
 
       // Create cache key based on URL and search parameter
       const cacheKey = `docs:${url}:${search || ''}`;
-      
+
       // Check cache first
       const cached = this.cache.get(cacheKey);
       if (cached) {
         return cached;
       }
 
-      const response = await fetch(url);
+      const response = await this.fetch(url);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -186,7 +196,7 @@ class FluxDocumentationServer {
       // Extract main content
       const content = $('main, .prose, .documentation, .content').first();
       let text = '';
-      
+
       if (content.length > 0) {
         text = content.text().trim();
       } else {
@@ -208,13 +218,13 @@ class FluxDocumentationServer {
             if (headingText.includes('reference')) {
               let nextElement = $(el).next();
               let sectionContent = '';
-              
+
               // Collect content until next heading or end
               while (nextElement.length > 0 && !nextElement.is('h1, h2, h3, h4')) {
                 sectionContent += nextElement.text().trim() + '\n';
                 nextElement = nextElement.next();
               }
-              
+
               if (sectionContent.trim()) {
                 referenceText = sectionContent.trim();
                 return false; // Break the loop
@@ -233,7 +243,7 @@ class FluxDocumentationServer {
       // If search term is provided, filter content
       if (search) {
         const lines = combinedText.split('\n');
-        const filteredLines = lines.filter(line => 
+        const filteredLines = lines.filter(line =>
           line.toLowerCase().includes(search.toLowerCase())
         );
         combinedText = filteredLines.join('\n');
@@ -250,7 +260,7 @@ class FluxDocumentationServer {
 
       // Cache the result
       this.cache.set(cacheKey, result);
-      
+
       return result;
     } catch (error) {
       throw new Error(`Failed to fetch documentation: ${error.message}`);
@@ -260,14 +270,14 @@ class FluxDocumentationServer {
   async listFluxComponents() {
     try {
       const cacheKey = 'components:list';
-      
+
       // Check cache first
       const cached = this.cache.get(cacheKey);
       if (cached) {
         return cached;
       }
 
-      const response = await fetch('https://fluxui.dev/docs');
+      const response = await this.fetch('https://fluxui.dev/docs');
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -280,7 +290,7 @@ class FluxDocumentationServer {
       $('a').each((i, el) => {
         const href = $(el).attr('href');
         const text = $(el).text().trim();
-        
+
         // Filter for links that start with https://fluxui.dev/components/
         if (href && text && href.startsWith('https://fluxui.dev/components/') && !links.some(l => l.href === href)) {
           links.push({
@@ -306,7 +316,7 @@ class FluxDocumentationServer {
 
       // Cache the result
       this.cache.set(cacheKey, result);
-      
+
       return result;
     } catch (error) {
       throw new Error(`Failed to list components: ${error.message}`);
@@ -316,14 +326,14 @@ class FluxDocumentationServer {
   async listFluxLayouts() {
     try {
       const cacheKey = 'layouts:list';
-      
+
       // Check cache first
       const cached = this.cache.get(cacheKey);
       if (cached) {
         return cached;
       }
 
-      const response = await fetch('https://fluxui.dev/layouts');
+      const response = await this.fetch('https://fluxui.dev/layouts');
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -336,7 +346,7 @@ class FluxDocumentationServer {
       $('a').each((i, el) => {
         const href = $(el).attr('href');
         const text = $(el).text().trim();
-        
+
         // Filter for links that start with https://fluxui.dev/layouts/
         if (href && text && href.startsWith('https://fluxui.dev/layouts/') && !links.some(l => l.href === href)) {
           links.push({
@@ -362,7 +372,7 @@ class FluxDocumentationServer {
 
       // Cache the result
       this.cache.set(cacheKey, result);
-      
+
       return result;
     } catch (error) {
       throw new Error(`Failed to list layouts: ${error.message}`);
@@ -373,7 +383,7 @@ class FluxDocumentationServer {
     try {
       // Create cache key based on variant and search parameters
       const cacheKey = `icons:${variant || 'all'}:${search || ''}`;
-      
+
       // Check cache first
       const cached = this.cache.get(cacheKey);
       if (cached) {
@@ -388,21 +398,21 @@ class FluxDocumentationServer {
           usage: '<flux:icon.{name} />'
         },
         solid: {
-          path: '24/solid', 
+          path: '24/solid',
           size: '24px',
           style: 'solid',
           usage: '<flux:icon.{name} variant="solid" />'
         },
         mini: {
           path: '20/solid',
-          size: '20px', 
+          size: '20px',
           style: 'solid',
           usage: '<flux:icon.{name} variant="mini" />'
         },
         micro: {
           path: '16/solid',
           size: '16px',
-          style: 'solid', 
+          style: 'solid',
           usage: '<flux:icon.{name} variant="micro" />'
         }
       };
@@ -413,8 +423,8 @@ class FluxDocumentationServer {
       for (const variantName of variantsToFetch) {
         const variantConfig = variants[variantName];
         const url = `https://api.github.com/repos/tailwindlabs/heroicons/contents/optimized/${variantConfig.path}`;
-        
-        const response = await fetch(url);
+
+        const response = await this.fetch(url);
         if (!response.ok) {
           throw new Error(`Failed to fetch ${variantName} icons: ${response.status}`);
         }
@@ -432,13 +442,13 @@ class FluxDocumentationServer {
       }
 
       let result = 'Available Heroicons for flux:icon component:\n\n';
-      
+
       for (const [variantName, data] of Object.entries(allIcons)) {
         const { config, icons } = data;
         result += `## ${variantName.toUpperCase()} (${config.size} ${config.style})\n`;
         result += `Usage: ${config.usage}\n`;
         result += `GitHub: https://github.com/tailwindlabs/heroicons/tree/master/optimized/${config.path}\n\n`;
-        
+
         if (icons.length === 0) {
           result += `No icons found${search ? ` matching "${search}"` : ''}.\n\n`;
         } else {
@@ -463,7 +473,7 @@ class FluxDocumentationServer {
 
       // Cache the result
       this.cache.set(cacheKey, finalResult);
-      
+
       return finalResult;
     } catch (error) {
       throw new Error(`Failed to list icons: ${error.message}`);
@@ -477,5 +487,12 @@ class FluxDocumentationServer {
   }
 }
 
-const server = new FluxDocumentationServer();
-server.run().catch(console.error);
+// Only auto-start when executed as the CLI entrypoint, not when imported by tests.
+const invokedAsMain =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+
+if (invokedAsMain) {
+  const server = new FluxDocumentationServer();
+  server.run().catch(console.error);
+}

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -1,13 +1,13 @@
-import { describe, test, mock } from 'node:test';
+import { describe, test, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { FluxDocumentationServer, SimpleCache } from '../../index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Load fixtures
 const componentFixture = readFileSync(
   join(__dirname, '../fixtures/component.html'),
   'utf-8'
@@ -20,219 +20,236 @@ const iconsApiFixture = JSON.parse(
   readFileSync(join(__dirname, '../fixtures/icons-api.json'), 'utf-8')
 );
 
-describe('FluxDocumentationServer Integration', () => {
-  describe('fetch_flux_docs tool', () => {
-    test('fetches component documentation', async () => {
-      // Mock fetch to return fixture
-      const originalFetch = global.fetch;
-      global.fetch = mock.fn(async (url) => ({
-        ok: true,
-        status: 200,
-        text: async () => componentFixture
-      }));
+const okText = (body) => ({
+  ok: true,
+  status: 200,
+  text: async () => body,
+});
 
-      // Test would invoke the actual tool here
-      // For now, verify the mock works
-      const response = await global.fetch('https://fluxui.dev/components/button');
-      const html = await response.text();
+const okJson = (body) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+});
 
-      assert.ok(html.includes('Button'));
-      assert.ok(html.includes('Reference'));
+const httpError = (status) => ({
+  ok: false,
+  status,
+  statusText: 'error',
+});
 
-      global.fetch = originalFetch;
+const buildServer = (fetchImpl) =>
+  new FluxDocumentationServer({ fetch: fetchImpl });
+
+describe('FluxDocumentationServer integration', () => {
+  describe('fetchFluxDocs', () => {
+    test('returns MCP-shaped response with component documentation', async () => {
+      const server = buildServer(mock.fn(async () => okText(componentFixture)));
+
+      const result = await server.fetchFluxDocs('button', undefined, undefined);
+
+      assert.ok(Array.isArray(result.content));
+      assert.strictEqual(result.content[0].type, 'text');
+      assert.match(result.content[0].text, /Documentation from https:\/\/fluxui\.dev\/components\/button/);
+      assert.match(result.content[0].text, /Button/);
     });
 
-    test('handles network errors gracefully', async () => {
-      const originalFetch = global.fetch;
-      global.fetch = mock.fn(async () => {
-        throw new Error('Network error');
-      });
+    test('targets the layouts URL when layout is provided', async () => {
+      const fetchSpy = mock.fn(async () => okText(componentFixture));
+      const server = buildServer(fetchSpy);
 
-      try {
-        await global.fetch('https://fluxui.dev/components/button');
-        assert.fail('Should have thrown an error');
-      } catch (error) {
-        assert.strictEqual(error.message, 'Network error');
-      }
+      await server.fetchFluxDocs(undefined, 'header', undefined);
 
-      global.fetch = originalFetch;
+      assert.strictEqual(fetchSpy.mock.callCount(), 1);
+      assert.strictEqual(
+        fetchSpy.mock.calls[0].arguments[0],
+        'https://fluxui.dev/layouts/header'
+      );
     });
 
-    test('handles HTTP errors (404, 500)', async () => {
-      const originalFetch = global.fetch;
-      global.fetch = mock.fn(async () => ({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found'
-      }));
-
-      const response = await global.fetch('https://fluxui.dev/components/invalid');
-      assert.strictEqual(response.ok, false);
-      assert.strictEqual(response.status, 404);
-
-      global.fetch = originalFetch;
-    });
-
-    test('filters content by search term', () => {
-      const content = `
-        Button documentation
-        Input documentation
-        Modal documentation
-      `;
-      const searchTerm = 'button';
-      const lines = content.split('\n');
-      const filtered = lines.filter(line =>
-        line.toLowerCase().includes(searchTerm.toLowerCase())
+    test('filters by search term (case-insensitive)', async () => {
+      const server = buildServer(
+        mock.fn(async () =>
+          okText('<main>Button docs\nInput docs\nModal docs</main>')
+        )
       );
 
-      assert.strictEqual(filtered.length, 1);
-      assert.ok(filtered[0].includes('Button'));
+      const result = await server.fetchFluxDocs(undefined, undefined, 'button');
+
+      assert.match(result.content[0].text, /Button docs/);
+      assert.doesNotMatch(result.content[0].text, /Modal docs/);
+    });
+
+    test('serves second identical call from cache (only one fetch)', async () => {
+      const fetchSpy = mock.fn(async () => okText(componentFixture));
+      const server = buildServer(fetchSpy);
+
+      const first = await server.fetchFluxDocs('button', undefined, undefined);
+      const second = await server.fetchFluxDocs('button', undefined, undefined);
+
+      assert.strictEqual(fetchSpy.mock.callCount(), 1);
+      assert.deepStrictEqual(second, first);
+    });
+
+    test('different search terms produce distinct cache keys', async () => {
+      const fetchSpy = mock.fn(async () => okText(componentFixture));
+      const server = buildServer(fetchSpy);
+
+      await server.fetchFluxDocs('button', undefined, 'foo');
+      await server.fetchFluxDocs('button', undefined, 'bar');
+
+      assert.strictEqual(fetchSpy.mock.callCount(), 2);
+    });
+
+    test('rejects with descriptive error on HTTP 404', async () => {
+      const server = buildServer(mock.fn(async () => httpError(404)));
+
+      await assert.rejects(
+        () => server.fetchFluxDocs('nope', undefined, undefined),
+        /Failed to fetch documentation:.*404/
+      );
+    });
+
+    test('rejects with descriptive error on network failure', async () => {
+      const server = buildServer(
+        mock.fn(async () => {
+          throw new Error('boom');
+        })
+      );
+
+      await assert.rejects(
+        () => server.fetchFluxDocs('button', undefined, undefined),
+        /Failed to fetch documentation:.*boom/
+      );
     });
   });
 
-  describe('list_flux_components tool', () => {
-    test('parses component list from HTML', async () => {
-      const originalFetch = global.fetch;
-      global.fetch = mock.fn(async () => ({
-        ok: true,
-        text: async () => componentsListFixture
-      }));
-
-      const response = await global.fetch('https://fluxui.dev/docs');
-      const html = await response.text();
-
-      // Verify fixture contains expected component links (check href attribute to avoid URL substring ambiguity)
-      assert.ok(html.includes('href="https://fluxui.dev/components/button"'));
-      assert.ok(html.includes('href="https://fluxui.dev/components/input"'));
-      assert.ok(html.includes('href="https://fluxui.dev/components/modal"'));
-
-      global.fetch = originalFetch;
-    });
-
-    test('deduplicates component links', () => {
-      const links = [
-        { href: '/components/button', name: 'Button' },
-        { href: '/components/button', name: 'Button' },
-        { href: '/components/input', name: 'Input' }
-      ];
-
-      const unique = links.filter((link, index, self) =>
-        index === self.findIndex(l => l.href === link.href)
+  describe('listFluxComponents', () => {
+    test('parses component links from /docs and returns MCP shape', async () => {
+      const server = buildServer(
+        mock.fn(async () => okText(componentsListFixture))
       );
 
-      assert.strictEqual(unique.length, 2);
+      const result = await server.listFluxComponents();
+
+      assert.strictEqual(result.content[0].type, 'text');
+      assert.match(result.content[0].text, /Available Flux Components/);
+      assert.match(result.content[0].text, /button/);
+      assert.match(result.content[0].text, /input/);
+      assert.match(result.content[0].text, /modal/);
+    });
+
+    test('caches the listing across calls', async () => {
+      const fetchSpy = mock.fn(async () => okText(componentsListFixture));
+      const server = buildServer(fetchSpy);
+
+      await server.listFluxComponents();
+      await server.listFluxComponents();
+
+      assert.strictEqual(fetchSpy.mock.callCount(), 1);
+    });
+
+    test('rejects on HTTP error', async () => {
+      const server = buildServer(mock.fn(async () => httpError(500)));
+
+      await assert.rejects(() => server.listFluxComponents(), /Failed to list components/);
     });
   });
 
-  describe('list_flux_component_icons tool', () => {
-    test('fetches icons from GitHub API', async () => {
-      const originalFetch = global.fetch;
-      global.fetch = mock.fn(async () => ({
-        ok: true,
-        json: async () => iconsApiFixture
-      }));
-
-      const response = await global.fetch(
-        'https://api.github.com/repos/tailwindlabs/heroicons/contents/optimized/24/outline'
+  describe('listFluxLayouts', () => {
+    test('fetches the layouts index page', async () => {
+      const fetchSpy = mock.fn(async () =>
+        okText(
+          '<a href="https://fluxui.dev/layouts/header">Header</a>' +
+          '<a href="https://fluxui.dev/layouts/sidebar">Sidebar</a>'
+        )
       );
-      const icons = await response.json();
+      const server = buildServer(fetchSpy);
 
-      assert.ok(Array.isArray(icons));
-      assert.strictEqual(icons.length, 3);
-      assert.ok(icons.every(icon => icon.name.endsWith('.svg')));
+      const result = await server.listFluxLayouts();
 
-      global.fetch = originalFetch;
-    });
-
-    test('filters icons by search term', () => {
-      const icons = ['academic-cap', 'arrow-left', 'arrow-right', 'user'];
-      const searchTerm = 'arrow';
-
-      const filtered = icons.filter(icon =>
-        icon.toLowerCase().includes(searchTerm.toLowerCase())
+      assert.strictEqual(
+        fetchSpy.mock.calls[0].arguments[0],
+        'https://fluxui.dev/layouts'
       );
-
-      assert.strictEqual(filtered.length, 2);
-      assert.ok(filtered.includes('arrow-left'));
-      assert.ok(filtered.includes('arrow-right'));
-    });
-
-    test('removes .svg extension from icon names', () => {
-      const files = iconsApiFixture;
-      const iconNames = files
-        .filter(f => f.name.endsWith('.svg'))
-        .map(f => f.name.slice(0, -4));
-
-      assert.ok(iconNames.includes('academic-cap'));
-      assert.ok(iconNames.includes('arrow-left'));
-      assert.ok(iconNames.includes('user'));
-      assert.ok(iconNames.every(name => !name.endsWith('.svg')));
+      assert.match(result.content[0].text, /Header/);
+      assert.match(result.content[0].text, /Sidebar/);
     });
   });
 
-  describe('Cache behavior', () => {
-    test('caches responses with unique keys', () => {
-      const cache = new Map();
-      const key1 = 'docs:https://fluxui.dev/components/button:';
-      const key2 = 'docs:https://fluxui.dev/components/input:';
+  describe('listFluxComponentIcons', () => {
+    test('fetches all 4 variants when none specified', async () => {
+      const fetchSpy = mock.fn(async () => okJson(iconsApiFixture));
+      const server = buildServer(fetchSpy);
 
-      cache.set(key1, { content: 'Button docs' });
-      cache.set(key2, { content: 'Input docs' });
+      const result = await server.listFluxComponentIcons(undefined, undefined);
 
-      assert.strictEqual(cache.size, 2);
-      assert.notStrictEqual(cache.get(key1), cache.get(key2));
+      assert.strictEqual(fetchSpy.mock.callCount(), 4);
+      assert.match(result.content[0].text, /OUTLINE/);
+      assert.match(result.content[0].text, /SOLID/);
+      assert.match(result.content[0].text, /MINI/);
+      assert.match(result.content[0].text, /MICRO/);
     });
 
-    test('includes search parameter in cache key', () => {
-      const url = 'https://fluxui.dev/components/button';
-      const search1 = 'form';
-      const search2 = 'validation';
+    test('fetches only one variant when specified', async () => {
+      const fetchSpy = mock.fn(async () => okJson(iconsApiFixture));
+      const server = buildServer(fetchSpy);
 
-      const key1 = `docs:${url}:${search1}`;
-      const key2 = `docs:${url}:${search2}`;
+      await server.listFluxComponentIcons('outline', undefined);
 
-      assert.notStrictEqual(key1, key2);
+      assert.strictEqual(fetchSpy.mock.callCount(), 1);
+      assert.match(
+        fetchSpy.mock.calls[0].arguments[0],
+        /optimized\/24\/outline$/
+      );
     });
 
-    test('cache hit returns same data', () => {
-      const cache = new Map();
-      const key = 'test-key';
-      const data = { content: 'test data' };
+    test('search filter narrows icon list', async () => {
+      const server = buildServer(mock.fn(async () => okJson(iconsApiFixture)));
 
-      cache.set(key, data);
-      const retrieved = cache.get(key);
+      const result = await server.listFluxComponentIcons('outline', 'arrow');
 
-      assert.strictEqual(retrieved, data);
+      assert.match(result.content[0].text, /arrow-left/);
+      assert.doesNotMatch(result.content[0].text, /academic-cap/);
+    });
+
+    test('strips .svg from icon names', async () => {
+      const server = buildServer(mock.fn(async () => okJson(iconsApiFixture)));
+
+      const result = await server.listFluxComponentIcons('outline', undefined);
+
+      assert.doesNotMatch(result.content[0].text, /\.svg/);
+    });
+
+    test('caches results by (variant, search) combination', async () => {
+      const fetchSpy = mock.fn(async () => okJson(iconsApiFixture));
+      const server = buildServer(fetchSpy);
+
+      await server.listFluxComponentIcons('outline', undefined);
+      await server.listFluxComponentIcons('outline', undefined);
+
+      assert.strictEqual(fetchSpy.mock.callCount(), 1);
+    });
+
+    test('rejects on GitHub HTTP error', async () => {
+      const server = buildServer(mock.fn(async () => httpError(403)));
+
+      await assert.rejects(
+        () => server.listFluxComponentIcons('outline', undefined),
+        /Failed to list icons/
+      );
     });
   });
 
-  describe('Error handling', () => {
-    test('wraps errors in MCP response format', () => {
-      const errorMessage = 'Failed to fetch documentation';
-      const response = {
-        content: [
-          {
-            type: 'text',
-            text: `Error: ${errorMessage}`
-          }
-        ]
-      };
-
-      assert.ok(Array.isArray(response.content));
-      assert.ok(response.content[0].text.startsWith('Error:'));
+  describe('FluxDocumentationServer construction', () => {
+    test('exposes a SimpleCache instance', () => {
+      const server = buildServer(mock.fn(async () => okText('')));
+      assert.ok(server.cache instanceof SimpleCache);
     });
 
-    test('provides descriptive error messages', () => {
-      const errors = [
-        'Failed to fetch documentation: Network error',
-        'Failed to list components: HTTP error! status: 404',
-        'Failed to list icons: GitHub API rate limit exceeded'
-      ];
-
-      errors.forEach(error => {
-        assert.ok(error.includes('Failed to'));
-        assert.ok(error.includes(':'));
-      });
+    test('defaults to bundled fetch implementation when none injected', () => {
+      const server = new FluxDocumentationServer();
+      assert.ok(typeof server.fetch === 'function');
     });
   });
 });

--- a/test/unit/cache.test.js
+++ b/test/unit/cache.test.js
@@ -1,36 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
-
-// Simple cache implementation for testing
-class SimpleCache {
-  constructor(ttlMs = 24 * 60 * 60 * 1000) {
-    this.cache = new Map();
-    this.ttl = ttlMs;
-  }
-
-  get(key) {
-    const entry = this.cache.get(key);
-    if (!entry) return null;
-
-    if (Date.now() - entry.timestamp > this.ttl) {
-      this.cache.delete(key);
-      return null;
-    }
-
-    return entry.data;
-  }
-
-  set(key, data) {
-    this.cache.set(key, {
-      data,
-      timestamp: Date.now()
-    });
-  }
-
-  clear() {
-    this.cache.clear();
-  }
-}
+import { SimpleCache } from '../../index.js';
 
 describe('SimpleCache', () => {
   test('stores and retrieves data', () => {

--- a/test/unit/tools.test.js
+++ b/test/unit/tools.test.js
@@ -1,181 +1,84 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
+import { TOOL_DEFINITIONS } from '../../index.js';
+
+const byName = (name) => TOOL_DEFINITIONS.find((t) => t.name === name);
 
 describe('MCP Tool Schemas', () => {
-  const expectedTools = [
-    'fetch_flux_docs',
-    'list_flux_components',
-    'list_flux_layouts',
-    'list_flux_component_icons'
-  ];
-
-  test('server defines all 4 expected tools', () => {
-    // This validates the tool count matches documentation
-    assert.strictEqual(expectedTools.length, 4);
+  test('exports exactly 4 tools', () => {
+    assert.strictEqual(TOOL_DEFINITIONS.length, 4);
   });
 
-  describe('fetch_flux_docs tool', () => {
-    test('has correct schema structure', () => {
-      const schema = {
-        name: 'fetch_flux_docs',
-        description: 'Fetch documentation for Livewire Flux components or layouts from fluxui.dev',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            component: {
-              type: 'string',
-              description: 'The component name or path to fetch documentation for (optional)',
-            },
-            layout: {
-              type: 'string',
-              description: 'The layout name to fetch documentation for (e.g., "header", "sidebar") (optional)',
-            },
-            search: {
-              type: 'string',
-              description: 'Search term to find specific documentation (optional)',
-            },
-          },
-        },
-      };
+  test('each tool has name, description, inputSchema.type=object', () => {
+    for (const tool of TOOL_DEFINITIONS) {
+      assert.ok(typeof tool.name === 'string' && tool.name.length > 0);
+      assert.ok(typeof tool.description === 'string' && tool.description.length > 0);
+      assert.strictEqual(tool.inputSchema.type, 'object');
+      assert.ok(typeof tool.inputSchema.properties === 'object');
+    }
+  });
 
-      assert.strictEqual(schema.name, 'fetch_flux_docs');
-      assert.strictEqual(schema.inputSchema.type, 'object');
-      assert.ok(schema.inputSchema.properties.component);
-      assert.ok(schema.inputSchema.properties.layout);
-      assert.ok(schema.inputSchema.properties.search);
+  describe('fetch_flux_docs', () => {
+    const tool = byName('fetch_flux_docs');
+
+    test('exists', () => {
+      assert.ok(tool, 'fetch_flux_docs tool must be defined');
     });
 
-    test('all parameters are optional', () => {
-      // Test that tool can be called with no parameters
-      const validCalls = [
-        {},
-        { component: 'button' },
-        { layout: 'header' },
-        { search: 'form' },
-        { component: 'input', search: 'validation' }
-      ];
+    test('has component, layout, search properties (all optional)', () => {
+      assert.ok(tool.inputSchema.properties.component);
+      assert.ok(tool.inputSchema.properties.layout);
+      assert.ok(tool.inputSchema.properties.search);
+      assert.strictEqual(tool.inputSchema.required, undefined);
+    });
 
-      validCalls.forEach(params => {
-        // In real implementation, these would be valid
-        assert.ok(typeof params === 'object');
-      });
+    test('all three params are strings', () => {
+      assert.strictEqual(tool.inputSchema.properties.component.type, 'string');
+      assert.strictEqual(tool.inputSchema.properties.layout.type, 'string');
+      assert.strictEqual(tool.inputSchema.properties.search.type, 'string');
     });
   });
 
-  describe('list_flux_components tool', () => {
-    test('has correct schema structure', () => {
-      const schema = {
-        name: 'list_flux_components',
-        description: 'List all available Flux components from the documentation',
-        inputSchema: {
-          type: 'object',
-          properties: {},
-        },
-      };
+  describe('list_flux_components', () => {
+    const tool = byName('list_flux_components');
 
-      assert.strictEqual(schema.name, 'list_flux_components');
-      assert.strictEqual(schema.inputSchema.type, 'object');
-      assert.strictEqual(Object.keys(schema.inputSchema.properties).length, 0);
+    test('exists', () => {
+      assert.ok(tool);
     });
 
-    test('accepts no parameters', () => {
-      const params = {};
-      assert.strictEqual(Object.keys(params).length, 0);
+    test('takes no parameters', () => {
+      assert.strictEqual(Object.keys(tool.inputSchema.properties).length, 0);
     });
   });
 
-  describe('list_flux_layouts tool', () => {
-    test('has correct schema structure', () => {
-      const schema = {
-        name: 'list_flux_layouts',
-        description: 'List all available Flux layouts from the documentation',
-        inputSchema: {
-          type: 'object',
-          properties: {},
-        },
-      };
+  describe('list_flux_layouts', () => {
+    const tool = byName('list_flux_layouts');
 
-      assert.strictEqual(schema.name, 'list_flux_layouts');
-      assert.strictEqual(schema.inputSchema.type, 'object');
+    test('exists', () => {
+      assert.ok(tool);
+    });
+
+    test('takes no parameters', () => {
+      assert.strictEqual(Object.keys(tool.inputSchema.properties).length, 0);
     });
   });
 
-  describe('list_flux_component_icons tool', () => {
-    test('has correct schema structure', () => {
-      const schema = {
-        name: 'list_flux_component_icons',
-        description: 'List all available Heroicons for use with flux:icon component, with variants and usage examples',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            variant: {
-              type: 'string',
-              enum: ['outline', 'solid', 'mini', 'micro'],
-              description: 'Filter icons by variant (optional)',
-            },
-            search: {
-              type: 'string',
-              description: 'Search term to filter icon names (optional)',
-            },
-          },
-        },
-      };
+  describe('list_flux_component_icons', () => {
+    const tool = byName('list_flux_component_icons');
 
-      assert.strictEqual(schema.name, 'list_flux_component_icons');
-      assert.ok(schema.inputSchema.properties.variant);
-      assert.ok(schema.inputSchema.properties.search);
+    test('exists', () => {
+      assert.ok(tool);
     });
 
-    test('variant parameter accepts valid enum values', () => {
-      const validVariants = ['outline', 'solid', 'mini', 'micro'];
-
-      validVariants.forEach(variant => {
-        assert.ok(['outline', 'solid', 'mini', 'micro'].includes(variant));
-      });
+    test('variant enum is exactly the four supported variants', () => {
+      assert.deepStrictEqual(
+        tool.inputSchema.properties.variant.enum,
+        ['outline', 'solid', 'mini', 'micro']
+      );
     });
 
-    test('parameters are optional', () => {
-      const validCalls = [
-        {},
-        { variant: 'outline' },
-        { search: 'arrow' },
-        { variant: 'solid', search: 'user' }
-      ];
-
-      validCalls.forEach(params => {
-        assert.ok(typeof params === 'object');
-      });
-    });
-  });
-
-  describe('MCP Response Format', () => {
-    test('responses follow MCP content format', () => {
-      const validResponse = {
-        content: [
-          {
-            type: 'text',
-            text: 'Sample documentation content'
-          }
-        ]
-      };
-
-      assert.ok(Array.isArray(validResponse.content));
-      assert.strictEqual(validResponse.content[0].type, 'text');
-      assert.ok(typeof validResponse.content[0].text === 'string');
-    });
-
-    test('error responses follow MCP format', () => {
-      const errorResponse = {
-        content: [
-          {
-            type: 'text',
-            text: 'Error: Failed to fetch documentation'
-          }
-        ]
-      };
-
-      assert.ok(Array.isArray(errorResponse.content));
-      assert.ok(errorResponse.content[0].text.startsWith('Error:'));
+    test('search property is a string', () => {
+      assert.strictEqual(tool.inputSchema.properties.search.type, 'string');
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes the three load-bearing audit findings: the green test badge will mean something after this lands.

Audit reference: `~/.claude/PAI/MEMORY/WORK/audit-livewire-flux-mcp/ISA.md`

## What changed

- **`index.js`** — exports `SimpleCache`, `FluxDocumentationServer`, and `TOOL_DEFINITIONS` as named exports; reads the MCP server version from `package.json` instead of the hardcoded `'1.0.0'`; accepts `fetch` as a constructor dependency so tests can mock it cleanly; the stdio transport only starts when the file is the CLI entrypoint (`import.meta.url` main-module guard) so test imports no longer fork a server.
- **`test/unit/cache.test.js`** + **`test/unit/tools.test.js`** + **`test/integration/server.test.js`** — rewritten to import from `../../index.js` and exercise the real exports / real `FluxDocumentationServer` methods. The integration suite now covers caching, URL targeting, search filtering, and error paths via fetch-injection.
- **`.github/workflows/test.yml`** (new) — runs `npm ci && npm test` on every PR and on `push: main` (Node 24, 5-min cap).
- **`.github/workflows/publish.yml`** — runs `npm ci && npm test` before `npm publish`. Node bumped 22 → 24 to match `.node-version`.
- **`.github/workflows/dependabot-auto-merge.yml`** — waits on `lewagon/wait-on-check-action@v1.3.4` for the Test workflow's `success` conclusion before invoking `gh pr merge --auto`.

## Audit findings addressed

| ID | Finding | Fix |
|----|---------|-----|
| H1 | CI never ran tests; Dependabot auto-merge fired with no verification, and `publish.yml` shipped to npm without `npm test` | New `test.yml` workflow + `publish.yml` gates on it + `dependabot-auto-merge.yml` waits on it |
| H2 | Tests redefined their own copy of `SimpleCache` / schema literals; nothing in `test/` imported `index.js` — 32 green tests gave false confidence | All three test files now import from `index.js` and exercise the real classes via constructor injection |
| H3 | MCP server reported `version: '1.0.0'` to clients while the package was 2.1.17 | Version read from `package.json` at startup |

## Test count

- Before: 32 pass (against duplicated copies of the implementation)
- After: **38 pass** (against the real exports), `npm test` exits 0

## Why this PR first

PR2 (`improve/package-hygiene`) and PR3 (`improve/fetch-hardening`) are open in parallel and **independent of each other**, but they both benefit from this branch landing on `main` first: once `test.yml` is on `main`, the Test workflow runs on those PRs automatically and they merge with a real CI signal.

## Out of scope

- LOW audit items (empty `Plans/` dir, README MCP-client examples, LRU cache).
- TypeScript migration; module split of `index.js`.
- Branch-protection rule config (your GitHub-side call — recommend requiring the new `test` check before merging into `main`).