### PR TITLE
deps: drop node-fetch, move npm-check-updates to dev, declare engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
 
 class SimpleCache {

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ export class SimpleCache {
 }
 
 export class FluxDocumentationServer {
-  constructor({ fetch: fetchImpl = defaultFetch } = {}) {
+  constructor({ fetch: fetchImpl = globalThis.fetch } = {}) {
     this.server = new Server(
       {
         name: 'livewire-flux-mcp',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,16 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "cheerio": "^1.2.0",
-        "node-fetch": "^3.3.2",
-        "npm-check-updates": "^22.2.0"
+        "cheerio": "^1.2.0"
       },
       "bin": {
         "livewire-flux-mcp": "index.js"
+      },
+      "devDependencies": {
+        "npm-check-updates": "^22.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@hono/node-server": {
@@ -341,15 +345,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -634,29 +629,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -676,18 +648,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -989,48 +949,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/npm-check-updates": {
       "version": "22.2.0",
       "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.0.tgz",
       "integrity": "sha512-kaxgbkGkCOtoSrsUXShgcEiEfrRPqmOGk6Yeya+5hoNptblu9vuE8/PLABUSJz+IeNgKJBFxcC3UrBYmKsB8iA==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "ncu": "build/cli.js",
@@ -1481,15 +1404,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,14 @@
     "url": "https://github.com/leMaur/livewire-flux-mcp/issues"
   },
   "homepage": "https://github.com/leMaur/livewire-flux-mcp#readme",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "cheerio": "^1.2.0",
-    "node-fetch": "^3.3.2",
+    "cheerio": "^1.2.0"
+  },
+  "devDependencies": {
     "npm-check-updates": "^22.2.0"
   }
 }


### PR DESCRIPTION
## Summary

Three-line `package.json` cleanup + one removed import. Every end-user install gets smaller; every Node version mismatch fails at install instead of at first `fetch()` call.

Audit reference: `~/.claude/PAI/MEMORY/WORK/audit-livewire-flux-mcp/ISA.md` (findings H4, M1, M2).

## What changed

- **`package.json`** — `node-fetch` removed from `dependencies`; `npm-check-updates` moved from `dependencies` → `devDependencies`; new `"engines": { "node": ">=20" }`.
- **`index.js`** — removed `import fetch from 'node-fetch';` (Node 20+ has native `fetch` with the same API for everything we use here).
- **`package-lock.json`** — shrinks by ~90 lines.

## Audit findings addressed

| ID | Finding | Fix |
|----|---------|-----|
| H4 | `npm-check-updates` was in runtime `dependencies` despite being a dev-only interactive CLI invoked only via `npm run update` | Moved to `devDependencies` |
| M1 | `node-fetch` redundant on Node ≥18; `.node-version` pins 24 | Dependency removed; `index.js` uses native global `fetch` |
| M2 | No `engines` field — install succeeded on incompatible Node and crashed at first `fetch()` | `"engines": { "node": ">=20" }` declared |

## Tests

32 tests pass locally with the new `package.json` and native `fetch`. (Once #44 merges, the new Test workflow will run on this PR automatically.)

## Independence

This PR is **independent of #44 and #46**. It can land in any order. Merging #44 first is recommended only so this PR picks up a real CI signal.

## Out of scope

- The deeper test refactor lives in #44.
- The fetch-call hardening (timeout, User-Agent, GITHUB_TOKEN) lives in #46.