### PR TITLE
harden: timeout + User-Agent + optional GITHUB_TOKEN + isError on errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,15 @@ const pkg = JSON.parse(
   readFileSync(join(__dirname, 'package.json'), 'utf-8')
 );
 
+const REQUEST_TIMEOUT_MS = 10_000;
+const USER_AGENT = `livewire-flux-mcp/${pkg.version} (+https://github.com/leMaur/livewire-flux-mcp)`;
+
+function githubAuthHeaders() {
+  return process.env.GITHUB_TOKEN
+    ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+    : {};
+}
+
 export const TOOL_DEFINITIONS = [
   {
     name: 'fetch_flux_docs',
@@ -125,6 +134,25 @@ export class FluxDocumentationServer {
     this.setupToolHandlers();
   }
 
+  async fetchWithTimeout(url, { headers = {}, timeoutMs = REQUEST_TIMEOUT_MS } = {}) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      return await this.fetch(url, {
+        headers: { 'User-Agent': USER_AGENT, ...headers },
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        throw new Error(`Request timed out after ${timeoutMs}ms: ${url}`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   setupToolHandlers() {
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
       return { tools: TOOL_DEFINITIONS };
@@ -148,6 +176,7 @@ export class FluxDocumentationServer {
         }
       } catch (error) {
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -185,7 +214,7 @@ export class FluxDocumentationServer {
         return cached;
       }
 
-      const response = await this.fetch(url);
+      const response = await this.fetchWithTimeout(url);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -277,7 +306,7 @@ export class FluxDocumentationServer {
         return cached;
       }
 
-      const response = await this.fetch('https://fluxui.dev/docs');
+      const response = await this.fetchWithTimeout('https://fluxui.dev/docs');
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -333,7 +362,7 @@ export class FluxDocumentationServer {
         return cached;
       }
 
-      const response = await this.fetch('https://fluxui.dev/layouts');
+      const response = await this.fetchWithTimeout('https://fluxui.dev/layouts');
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -424,7 +453,7 @@ export class FluxDocumentationServer {
         const variantConfig = variants[variantName];
         const url = `https://api.github.com/repos/tailwindlabs/heroicons/contents/optimized/${variantConfig.path}`;
 
-        const response = await this.fetch(url);
+        const response = await this.fetchWithTimeout(url, { headers: githubAuthHeaders() });
         if (!response.ok) {
           throw new Error(`Failed to fetch ${variantName} icons: ${response.status}`);
         }


### PR DESCRIPTION
## Summary

Production-path hardening for the four outbound HTTP calls. No client-visible behavior change on the happy path; failure paths now name what timed out, identify ourselves to GitHub / fluxui.dev, and lift the anonymous GitHub rate-limit cliff.

Audit reference: `~/.claude/PAI/MEMORY/WORK/audit-livewire-flux-mcp/ISA.md` (findings M3, M4, M5, M6).

## What changed

- **`fetchWithTimeout(url, { headers, timeoutMs })`** — new module-private helper using `AbortController`. Default 10s deadline. On abort, throws `Request timed out after Nms: <url>` instead of an opaque `AbortError`.
- All four outbound calls (`fluxui.dev/components/`, `/docs`, `/layouts`, `api.github.com/...heroicons...`) routed through it.
- Every request sends `User-Agent: livewire-flux-mcp (+https://github.com/leMaur/livewire-flux-mcp)` — GitHub asks anonymous clients to identify themselves; courteous to fluxui.dev too.
- `listFluxComponentIcons` attaches `Authorization: Bearer ${GITHUB_TOKEN}` when the env var is set, lifting the anonymous 60/hr cap to 5000/hr. Absent token still works (graceful).
- The outer MCP error envelope in `setupToolHandlers` now sets `isError: true` so clients can distinguish errors from normal text content per MCP convention.

## Audit findings addressed

| ID | Finding | Fix |
|----|---------|-----|
| M3 | No timeout on `fetch()` — slow upstream stalled the MCP client indefinitely | `fetchWithTimeout` + 10s `AbortController` on all 4 callsites |
| M4 | No `User-Agent` header on any outbound call | `User-Agent` set on every request |
| M5 | Anonymous GitHub 60/hr cap; `list_flux_component_icons` makes 4 cold-cache calls | Optional `GITHUB_TOKEN` env support; works without it |
| M6 | MCP error envelope missed `isError: true` per spec | Flag added |

## Tests

32 tests pass locally. (Once #44 merges, the new Test workflow will run on this PR automatically.)

## Independence

This PR is **independent of #44 and #45**. It modifies only `index.js` and does not touch `package.json` or any workflow file.

## Future work (not this PR)

- README addition for the `GITHUB_TOKEN` env var. Will land in a follow-up when the docs sweep happens — kept out of this PR to stay surgical.