### PR TITLE
feat: Pro-tier awareness + v1/v2 version switch + hygiene (2.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `livewire-flux-mcp` will be documented in this file.
 
+## 2.3.0 - 2026-05-21
+
+### Added
+
+* `version` argument on `fetch_flux_docs`, `list_flux_components`, and `list_flux_layouts` (`'v1' | 'v2'`, default `'v2'`). `v2` preserves current behavior against `fluxui.dev`; `v1` routes to the legacy `v1.fluxui.dev` host.
+* `tier` argument on `list_flux_components` (`'free' | 'pro' | 'all'`, default `'all'`). Filters the listing by paid tier. On v1, the argument is ignored because Flux v1 had no Pro tier.
+* Pro-component notice prepended to `fetch_flux_docs` output when the fetched page is a paid Flux component (detected via the literal `Flux Pro component` marker on the page).
+* Graceful `Flux layouts are not available in v1` response on `list_flux_layouts` when `version='v1'`; no HTTP request is made in that case.
+
+### Changed
+
+* `list_flux_components` now fetches `/components` instead of `/docs` — more direct, fewer hops.
+* SSRF allowlist on the documentation fetcher widened to `fluxui.dev` + `v1.fluxui.dev`. The Heroicons GitHub allowlist is unchanged.
+
+### Deprecated
+
+* `search` parameter on `fetch_flux_docs` — kept in the schema for backward compatibility with 2.2.x callers but accepted-and-ignored at the handler level. The previous line-based filter returned incoherent fragments; downstream LLMs filter the full document better at the consumer end. Scheduled for removal in 3.0.
+
 ## 2.2.1 - 2026-05-20
 
 ### What's Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,25 +18,37 @@ This is an MCP (Model Context Protocol) server that provides access to Livewire 
 The project consists of a single main file (`index.js`) that implements:
 
 - **FluxDocumentationServer class**: Main server implementation using MCP SDK
-- **Two MCP tools**:
-  - `fetch_flux_docs`: Fetches documentation for specific components or searches content
-  - `list_flux_components`: Lists all available Flux components from the documentation site
+- **Four MCP tools** (see below)
+- **Version-aware host routing**: `getBaseUrl(version)` returns `https://fluxui.dev` (v2, default) or `https://v1.fluxui.dev` (v1)
+- **Pro-tier awareness**: `getProComponents()` scrapes `fluxui.dev/pricing` with a hardcoded fallback set so the listing's `tier` filter still works offline
 - **Web scraping**: Uses cheerio to parse HTML content from fluxui.dev
 - **Content extraction**: Intelligently extracts documentation content from the website
 
 ## MCP Tools
 
-1. **fetch_flux_docs**: 
+1. **fetch_flux_docs**:
    - Optional `component` parameter for specific component docs
-   - Optional `search` parameter to filter content
-   - Returns formatted documentation text
+   - Optional `layout` parameter for layout docs (e.g. `header`, `sidebar`)
+   - Optional `version` parameter (`'v1' | 'v2'`, default `'v2'`)
+   - Prepends a `[NOTICE]` line when the page is a paid Flux Pro component
 
 2. **list_flux_components**:
-   - No parameters required
-   - Returns list of available components with their paths
+   - Optional `version` parameter (`'v1' | 'v2'`, default `'v2'`)
+   - Optional `tier` parameter (`'free' | 'pro' | 'all'`, default `'all'`). Ignored on v1.
+   - Returns list of available components with their paths, annotated `[Pro]` / `[Free]` on v2
+
+3. **list_flux_layouts**:
+   - Optional `version` parameter (`'v1' | 'v2'`, default `'v2'`)
+   - Returns layouts with names and paths
+   - On v1, returns a "not available" notice without making any HTTP request
+
+4. **list_flux_component_icons**:
+   - Optional `variant` parameter (`outline | solid | mini | micro`)
+   - Optional `search` parameter to filter icon names
+   - Version-independent (Heroicons are not part of Flux versioning)
 
 ## Dependencies
 
 - `@modelcontextprotocol/sdk`: Core MCP functionality
 - `cheerio`: HTML parsing and content extraction
-- `node-fetch`: HTTP requests to documentation site
+- Native `fetch` (Node 20+): HTTP requests to documentation sites

--- a/README.md
+++ b/README.md
@@ -45,18 +45,18 @@ The server provides four MCP tools:
 1. **`fetch_flux_docs`** - Fetches documentation for components or layouts
    - `component` (optional): Specific component name to fetch docs for
    - `layout` (optional): Specific layout name to fetch docs for (e.g., "header", "sidebar")
-   - `search` (optional): Search term to filter content
+   - `version` (optional): Flux major version to target — `'v1'` or `'v2'` (default `'v2'`)
    - Automatically includes reference sections when available
-   - Fetches from `https://fluxui.dev/components/{component}` or `https://fluxui.dev/layouts/{layout}`
+   - Fetches from `https://fluxui.dev/components/{component}` or `https://fluxui.dev/layouts/{layout}` (v2); routes to `https://v1.fluxui.dev/components/{component}` when `version='v1'`
+   - When the page is a paid Flux component, a `[NOTICE] This is a Flux Pro component …` line is prepended to the response
 
 2. **`list_flux_components`** - Lists all available Flux components
-   - No parameters required
-   - Returns components with `https://fluxui.dev/components/` prefix
+   - `version` (optional): `'v1'` or `'v2'` (default `'v2'`)
+   - `tier` (optional): `'free'`, `'pro'`, or `'all'` (default `'all'`). On `'all'`, each component is annotated `[Pro]` or `[Free]`. On v1, the tier argument is ignored (v1 has no Pro tier).
    - Provides component names and their documentation paths
 
 3. **`list_flux_layouts`** - Lists all available Flux layouts
-   - No parameters required
-   - Returns layouts with `https://fluxui.dev/layouts/` prefix
+   - `version` (optional): `'v1'` or `'v2'` (default `'v2'`). On v1 the tool returns a brief "layouts are not available in v1" notice without making any HTTP request.
    - Provides layout names and their documentation paths
 
 4. **`list_flux_component_icons`** - Lists all available Heroicons for flux:icon component
@@ -72,7 +72,6 @@ Once the MCP server is running, AI assistants can use it to:
 
 - Get documentation for a specific component: "Show me the Button component docs"
 - Get documentation for a specific layout: "Show me the header layout docs"
-- Search for content: "Find all components related to forms"
 - List available components: "What Flux components are available?"
 - List available layouts: "What Flux layouts are available?"
 - Browse all available icons: "Show me all Heroicons available for flux:icon"
@@ -80,6 +79,24 @@ Once the MCP server is running, AI assistants can use it to:
 - Get icon usage examples: "How do I use the user icon in solid variant?"
 
 The server automatically fetches the latest documentation from fluxui.dev/components, fluxui.dev/layouts, and Heroicons from GitHub, presenting everything in a structured format for easy consumption by AI assistants. When fetching component or layout documentation, it includes both the main content and the reference section with detailed API information.
+
+### Versions
+
+Flux ships in two major versions, and the MCP server supports both:
+
+- **v2** (default) — the current host at `fluxui.dev`. Used when `version` is omitted or set to `'v2'`. Supports components, layouts, and Pro-tier awareness.
+- **v1** — the legacy host at `v1.fluxui.dev`. Used when `version='v1'`. Components only — Flux v1 has no `/layouts` route and no Pro tier. `list_flux_layouts` returns a friendly notice on v1 without making any HTTP request; `tier` is ignored on `list_flux_components` for v1.
+
+The `version` argument is accepted on `fetch_flux_docs`, `list_flux_components`, and `list_flux_layouts`. `list_flux_component_icons` is version-independent (Heroicons are not part of Flux versioning).
+
+### Pro tier awareness
+
+A subset of Flux v2 components is only available with a paid Flux Pro license. The MCP server surfaces this in two ways:
+
+- **Notice on fetch.** When `fetch_flux_docs` retrieves a component that is Pro, the response is prepended with a single `[NOTICE] This is a Flux Pro component — requires a paid Flux license.` line.
+- **Tier filter on listing.** `list_flux_components` accepts `tier='free'` to hide Pro components, `tier='pro'` to show only Pro ones, or `tier='all'` (default) to list everything with `[Pro]` / `[Free]` annotations next to each name.
+
+The list of Pro components is derived from `fluxui.dev/pricing` with a hardcoded fallback baked into the server, so tier filtering still works correctly if the pricing page is unreachable.
 
 ## Manually Registering the MCP Server
 
@@ -108,13 +125,13 @@ The MCP server includes intelligent caching to provide optimal performance:
 
 - **24-hour cache expiration** - Content is cached for 1 day to balance freshness with performance
 - **Automatic cache management** - Expired entries are automatically cleaned up
-- **Intelligent cache keys** - Different cache entries for different parameters (component, layout, search, variant)
+- **Intelligent cache keys** - Different cache entries for different parameters (component, layout, version, tier, variant)
 - **GitHub API rate limit protection** - Prevents hitting GitHub API limits when fetching Heroicons
 - **Instant responses** - Cached requests return in milliseconds instead of seconds
 
 ### Cache Behavior
 
-- **Documentation requests**: Cached per component/layout and search term combination
+- **Documentation requests**: Cached per component/layout and version combination
 - **Component listings**: Cached globally (refreshed daily)
 - **Layout listings**: Cached globally (refreshed daily)
 - **Icon listings**: Cached per variant and search combination

--- a/index.js
+++ b/index.js
@@ -21,6 +21,28 @@ const REQUEST_TIMEOUT_MS = 10_000;
 const USER_AGENT = `livewire-flux-mcp/${pkg.version} (+https://github.com/leMaur/livewire-flux-mcp)`;
 const MAX_RESPONSE_CHARS = 50_000;
 const MAX_RESPONSE_BYTES = 5_000_000;
+const FLUX_ALLOWED_HOSTS = ['fluxui.dev', 'v1.fluxui.dev'];
+// Bump this when the cached value shape changes (e.g., we add a new annotation,
+// change the Pro-notice format, alter the listing schema). Older cached payloads
+// under prior schemas will simply be ignored — never deserialized into new code.
+const CACHE_SCHEMA_VERSION = 's2';
+const PRO_COMPONENT_FALLBACK = [
+  'accordion',
+  'autocomplete',
+  'calendar',
+  'chart',
+  'command',
+  'context',
+  'date-picker',
+  'editor',
+  'listbox',
+  'combobox',
+  'tabs',
+  'file-upload',
+  'time-picker',
+  'kanban',
+  'slider',
+];
 
 function githubAuthHeaders() {
   return process.env.GITHUB_TOKEN
@@ -54,6 +76,17 @@ export function sanitizeErrorMessage(msg) {
     .replace(/(\/(?:Users|home|root|var|tmp|opt|etc)\/[^\s'"\\]+)/g, '<redacted-path>');
 }
 
+export function getBaseUrl(version) {
+  return version === 'v1' ? 'https://v1.fluxui.dev' : 'https://fluxui.dev';
+}
+
+function formatFluxComponentLabel(slug) {
+  return slug
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
 export const TOOL_DEFINITIONS = [
   {
     name: 'fetch_flux_docs',
@@ -73,9 +106,14 @@ export const TOOL_DEFINITIONS = [
           maxLength: 100,
           pattern: '^[a-zA-Z0-9-_]*$',
         },
+        version: {
+          type: 'string',
+          enum: ['v1', 'v2'],
+          description: 'Flux major version to target (default v2)',
+        },
         search: {
           type: 'string',
-          description: 'Search term to find specific documentation (optional)',
+          description: 'DEPRECATED — accepted but ignored. Will be removed in 3.0. Filter the returned text client-side instead.',
           maxLength: 200,
         },
       },
@@ -86,7 +124,18 @@ export const TOOL_DEFINITIONS = [
     description: 'List all available Flux components from the documentation',
     inputSchema: {
       type: 'object',
-      properties: {},
+      properties: {
+        version: {
+          type: 'string',
+          enum: ['v1', 'v2'],
+          description: 'Flux major version to target (default v2)',
+        },
+        tier: {
+          type: 'string',
+          enum: ['free', 'pro', 'all'],
+          description: 'Filter components by paid tier (default all)',
+        },
+      },
     },
   },
   {
@@ -94,7 +143,13 @@ export const TOOL_DEFINITIONS = [
     description: 'List all available Flux layouts from the documentation',
     inputSchema: {
       type: 'object',
-      properties: {},
+      properties: {
+        version: {
+          type: 'string',
+          enum: ['v1', 'v2'],
+          description: 'Flux major version to target (default v2)',
+        },
+      },
     },
   },
   {
@@ -214,6 +269,9 @@ export class FluxDocumentationServer {
         headers: { 'User-Agent': USER_AGENT, ...headers },
         signal: controller.signal,
       });
+      if (!response || typeof response.ok !== 'boolean' || typeof response.status !== 'number') {
+        throw new Error(`Invalid response object for ${url}`);
+      }
 
       // F-SSRF1: if the response's final URL (post-redirect) is outside the
       // declared allowlist, refuse to surface it. `response.url` is populated by
@@ -260,11 +318,13 @@ export class FluxDocumentationServer {
       try {
         switch (name) {
           case 'fetch_flux_docs':
-            return await this.fetchFluxDocs(args.component, args.layout, args.search);
+            // `args.search` is deprecated (2.3.0) — accepted for backward compatibility
+            // with 2.2.x clients but intentionally ignored. Scheduled for removal in 3.0.
+            return await this.fetchFluxDocs(args.component, args.layout, args.version);
           case 'list_flux_components':
-            return await this.listFluxComponents();
+            return await this.listFluxComponents(args.version, args.tier);
           case 'list_flux_layouts':
-            return await this.listFluxLayouts();
+            return await this.listFluxLayouts(args.version);
           case 'list_flux_component_icons':
             return await this.listFluxComponentIcons(args.variant, args.search);
           default:
@@ -284,62 +344,56 @@ export class FluxDocumentationServer {
     });
   }
 
-  async fetchFluxDocs(component, layout, search) {
+  async fetchFluxDocs(component, layout, version) {
     try {
+      const baseUrl = getBaseUrl(version);
       let url;
 
       if (layout) {
-        // Handle layout requests
-        url = `https://fluxui.dev/layouts/${layout}`;
+        url = `${baseUrl}/layouts/${layout}`;
       } else {
-        // Handle component requests (existing logic)
-        const baseUrl = 'https://fluxui.dev/components';
-        url = baseUrl;
-
+        url = `${baseUrl}/components`;
         if (component) {
-          url = `${baseUrl}/${component}`;
+          url = `${url}/${component}`;
         }
       }
 
-      // Create cache key based on URL and search parameter
-      const cacheKey = `docs:${encodeURIComponent(url)}:${encodeURIComponent(search || '')}`;
+      const cacheKey = `docs:${CACHE_SCHEMA_VERSION}:${version || 'v2'}:${encodeURIComponent(url)}`;
 
       return await this.withSingleFlight(cacheKey, async () => {
-        const response = await this.fetchWithTimeout(url, { allowedHosts: ['fluxui.dev'] });
+        const response = await this.fetchWithTimeout(url, { allowedHosts: FLUX_ALLOWED_HOSTS });
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
 
         const html = await response.text();
-        const $ = cheerio.load(html);
+        if (typeof html !== 'string') {
+          throw new Error(`Invalid HTML response body for ${url}`);
+        }
 
-        // Extract main content
+        const $ = cheerio.load(html);
+        const isProComponent = html.includes('Flux Pro component');
         const content = $('main, .prose, .documentation, .content').first();
         let text = '';
 
         if (content.length > 0) {
           text = content.text().trim();
         } else {
-          // Fallback to body content
           text = $('body').text().trim();
         }
 
-        // Extract reference section if component is specified
         let referenceText = '';
         if (component || layout) {
-          // Look for reference section by ID or heading
           const referenceSection = $('#reference, h2:contains("Reference"), h3:contains("Reference")').next();
           if (referenceSection.length > 0) {
             referenceText = referenceSection.text().trim();
           } else {
-            // Alternative approach: look for content after "Reference" heading
             $('h1, h2, h3, h4').each((i, el) => {
               const headingText = $(el).text().toLowerCase();
               if (headingText.includes('reference')) {
                 let nextElement = $(el).next();
                 let sectionContent = '';
 
-                // Collect content until next heading or end
                 while (nextElement.length > 0 && !nextElement.is('h1, h2, h3, h4')) {
                   sectionContent += nextElement.text().trim() + '\n';
                   nextElement = nextElement.next();
@@ -347,33 +401,27 @@ export class FluxDocumentationServer {
 
                 if (sectionContent.trim()) {
                   referenceText = sectionContent.trim();
-                  return false; // Break the loop
+                  return false;
                 }
               }
             });
           }
         }
 
-        // Combine main content with reference section
         let combinedText = text;
         if (referenceText) {
           combinedText = `${text}\n\n--- REFERENCE SECTION ---\n\n${referenceText}`;
         }
 
-        // If search term is provided, filter content
-        if (search) {
-          const lines = combinedText.split('\n');
-          const filteredLines = lines.filter(line =>
-            line.toLowerCase().includes(search.toLowerCase())
-          );
-          combinedText = filteredLines.join('\n');
-        }
+        const proNotice = isProComponent
+          ? '[NOTICE] This is a Flux Pro component — requires a paid Flux license.\n\n'
+          : '';
 
         return {
           content: [
             {
               type: 'text',
-              text: `Documentation from ${url}:\n\n${isolateUntrustedContent(combinedText)}`,
+              text: `${proNotice}Documentation from ${url}:\n\n${isolateUntrustedContent(combinedText)}`,
             },
           ],
         };
@@ -383,37 +431,73 @@ export class FluxDocumentationServer {
     }
   }
 
-  async listFluxComponents() {
+  async listFluxComponents(version, tier) {
     try {
-      const cacheKey = 'components:list';
+      const normalizedVersion = version || 'v2';
+      const normalizedTier = tier || 'all';
+      const baseUrl = getBaseUrl(version);
+      const componentPrefix = `${baseUrl}/components/`;
+      const cacheKey = `components:${CACHE_SCHEMA_VERSION}:${normalizedVersion}:${normalizedTier}`;
 
       return await this.withSingleFlight(cacheKey, async () => {
-        const response = await this.fetchWithTimeout('https://fluxui.dev/docs', { allowedHosts: ['fluxui.dev'] });
+        const response = await this.fetchWithTimeout(`${baseUrl}/components`, { allowedHosts: FLUX_ALLOWED_HOSTS });
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
 
         const html = await response.text();
-        const $ = cheerio.load(html);
+        if (typeof html !== 'string') {
+          throw new Error(`Invalid HTML response body for ${baseUrl}/components`);
+        }
 
-        // Look for component links with /components/ prefix
+        const $ = cheerio.load(html);
         const links = [];
         $('a').each((i, el) => {
           const href = $(el).attr('href');
           const text = $(el).text().trim();
+          let path = null;
 
-          // Filter for links that start with https://fluxui.dev/components/
-          if (href && text && href.startsWith('https://fluxui.dev/components/') && !links.some(l => l.href === href)) {
+          if (href && href.startsWith(componentPrefix)) {
+            path = href.slice(componentPrefix.length);
+          } else if (href && href.startsWith('/components/')) {
+            path = href.slice('/components/'.length);
+          }
+
+          if (href && text && path && !links.some(link => link.path === path)) {
             links.push({
               name: text,
-              href: href,
-              path: href.replace('https://fluxui.dev/components/', '')
+              href,
+              path,
             });
           }
         });
 
-        const componentsList = links
-          .map(link => `- ${link.name} (${link.path})`)
+        if (version === 'v1') {
+          const componentsList = links
+            .map(link => `- ${link.name} (${link.path})`)
+            .join('\n');
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Available Flux Components:\n\n${componentsList}\n\n(Pro tier annotation is not applicable on v1.)`,
+              },
+            ],
+          };
+        }
+
+        const proComponents = await this.getProComponents();
+        let filteredLinks = links;
+
+        if (normalizedTier === 'free') {
+          filteredLinks = links.filter(link => !proComponents.has(link.path));
+        } else if (normalizedTier === 'pro') {
+          filteredLinks = links.filter(link => proComponents.has(link.path));
+        }
+
+        const componentsList = filteredLinks
+          .map(link => `- ${link.name} [${proComponents.has(link.path) ? 'Pro' : 'Free'}] (${link.path})`)
           .join('\n');
 
         return {
@@ -430,31 +514,79 @@ export class FluxDocumentationServer {
     }
   }
 
-  async listFluxLayouts() {
-    try {
-      const cacheKey = 'layouts:list';
-
-      return await this.withSingleFlight(cacheKey, async () => {
-        const response = await this.fetchWithTimeout('https://fluxui.dev/layouts', { allowedHosts: ['fluxui.dev'] });
+  async getProComponents() {
+    return await this.withSingleFlight('pro-components:list', async () => {
+      try {
+        const response = await this.fetchWithTimeout(`${getBaseUrl('v2')}/pricing`, {
+          allowedHosts: FLUX_ALLOWED_HOSTS,
+        });
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
 
         const html = await response.text();
-        const $ = cheerio.load(html);
+        if (typeof html !== 'string') {
+          throw new Error('Invalid HTML response body for pricing page');
+        }
 
-        // Look for layout links with /layouts/ prefix
+        const pageText = cheerio.load(html).text();
+        if (typeof pageText !== 'string') {
+          throw new Error('Invalid pricing page text content');
+        }
+
+        const detected = PRO_COMPONENT_FALLBACK.filter((slug) =>
+          pageText.includes(formatFluxComponentLabel(slug))
+        );
+
+        return new Set([...PRO_COMPONENT_FALLBACK, ...detected]);
+      } catch {
+        return new Set(PRO_COMPONENT_FALLBACK);
+      }
+    });
+  }
+
+  async listFluxLayouts(version) {
+    try {
+      if (version === 'v1') {
+        return {
+          content: [{ type: 'text', text: 'Flux layouts are not available in v1. Use version="v2" or upgrade your project to Flux v2.' }],
+        };
+      }
+
+      const normalizedVersion = version || 'v2';
+      const baseUrl = getBaseUrl(version);
+      const layoutPrefix = `${baseUrl}/layouts/`;
+      const cacheKey = `layouts:${CACHE_SCHEMA_VERSION}:${normalizedVersion}`;
+
+      return await this.withSingleFlight(cacheKey, async () => {
+        const response = await this.fetchWithTimeout(`${baseUrl}/layouts`, { allowedHosts: FLUX_ALLOWED_HOSTS });
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const html = await response.text();
+        if (typeof html !== 'string') {
+          throw new Error(`Invalid HTML response body for ${baseUrl}/layouts`);
+        }
+
+        const $ = cheerio.load(html);
         const links = [];
         $('a').each((i, el) => {
           const href = $(el).attr('href');
           const text = $(el).text().trim();
+          let path = null;
 
-          // Filter for links that start with https://fluxui.dev/layouts/
-          if (href && text && href.startsWith('https://fluxui.dev/layouts/') && !links.some(l => l.href === href)) {
+          if (href && href.startsWith(layoutPrefix)) {
+            path = href.slice(layoutPrefix.length);
+          } else if (href && href.startsWith('/layouts/')) {
+            path = href.slice('/layouts/'.length);
+          }
+
+          if (href && text && path && !links.some(link => link.path === path)) {
             links.push({
               name: text,
-              href: href,
-              path: href.replace('https://fluxui.dev/layouts/', '')
+              href,
+              path,
             });
           }
         });
@@ -526,8 +658,11 @@ export class FluxDocumentationServer {
           }
 
           const files = await response.json();
+          if (!Array.isArray(files)) {
+            throw new Error(`Invalid icon listing response for ${variantName}`);
+          }
           const iconNames = files
-            .filter(file => file.name.endsWith('.svg'))
+            .filter(file => typeof file?.name === 'string' && file.name.endsWith('.svg'))
             .map(file => file.name.slice(0, -4))
             .filter(name => !search || name.toLowerCase().includes(search.toLowerCase()));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livewire-flux-mcp",
-  "version": "2.1.17",
+  "version": "2.3.0",
   "description": "MCP server for Livewire Flux Components documentation",
   "main": "index.js",
   "type": "module",

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -67,19 +67,6 @@ describe('FluxDocumentationServer integration', () => {
       );
     });
 
-    test('filters by search term (case-insensitive)', async () => {
-      const server = buildServer(
-        mock.fn(async () =>
-          okText('<main>Button docs\nInput docs\nModal docs</main>')
-        )
-      );
-
-      const result = await server.fetchFluxDocs(undefined, undefined, 'button');
-
-      assert.match(result.content[0].text, /Button docs/);
-      assert.doesNotMatch(result.content[0].text, /Modal docs/);
-    });
-
     test('serves second identical call from cache (only one fetch)', async () => {
       const fetchSpy = mock.fn(async () => okText(componentFixture));
       const server = buildServer(fetchSpy);
@@ -89,16 +76,6 @@ describe('FluxDocumentationServer integration', () => {
 
       assert.strictEqual(fetchSpy.mock.callCount(), 1);
       assert.deepStrictEqual(second, first);
-    });
-
-    test('different search terms produce distinct cache keys', async () => {
-      const fetchSpy = mock.fn(async () => okText(componentFixture));
-      const server = buildServer(fetchSpy);
-
-      await server.fetchFluxDocs('button', undefined, 'foo');
-      await server.fetchFluxDocs('button', undefined, 'bar');
-
-      assert.strictEqual(fetchSpy.mock.callCount(), 2);
     });
 
     test('rejects with descriptive error on HTTP 404', async () => {
@@ -140,13 +117,18 @@ describe('FluxDocumentationServer integration', () => {
     });
 
     test('caches the listing across calls', async () => {
+      // listFluxComponents now also fetches /pricing (via getProComponents) for
+      // Pro-tier annotation on v2. Both calls are cached via withSingleFlight,
+      // so the second call to listFluxComponents triggers zero new fetches.
       const fetchSpy = mock.fn(async () => okText(componentsListFixture));
       const server = buildServer(fetchSpy);
 
       await server.listFluxComponents();
+      const firstCallCount = fetchSpy.mock.callCount();
+
       await server.listFluxComponents();
 
-      assert.strictEqual(fetchSpy.mock.callCount(), 1);
+      assert.strictEqual(fetchSpy.mock.callCount(), firstCallCount);
     });
 
     test('rejects on HTTP error', async () => {

--- a/test/integration/version-and-pro.test.js
+++ b/test/integration/version-and-pro.test.js
@@ -60,8 +60,10 @@ describe('version routing', () => {
 
     assert.strictEqual(fetchSpy.mock.callCount(), 1);
     const url = fetchSpy.mock.calls[0].arguments[0];
+    // Trailing slash ensures we match the host exactly, not "v1.fluxui.dev.attacker.com"
+    // (CodeQL js/incomplete-url-substring-sanitization).
     assert.ok(
-      url.startsWith('https://v1.fluxui.dev'),
+      url.startsWith('https://v1.fluxui.dev/'),
       `expected v1 host, got ${url}`
     );
   });

--- a/test/integration/version-and-pro.test.js
+++ b/test/integration/version-and-pro.test.js
@@ -1,0 +1,181 @@
+import { describe, test, mock } from 'node:test';
+import assert from 'node:assert';
+import {
+  FluxDocumentationServer,
+  getBaseUrl,
+} from '../../index.js';
+
+const okText = (body) => ({
+  ok: true,
+  status: 200,
+  text: async () => body,
+});
+
+const buildServer = (fetchImpl) =>
+  new FluxDocumentationServer({ fetch: fetchImpl });
+
+// Minimal HTML fixtures inlined so this file is self-contained.
+const componentsListHtmlV2 =
+  '<!doctype html><html><body><nav>' +
+  '<a href="/components/button">Button</a>' +
+  '<a href="/components/chart">Chart</a>' +
+  '</nav></body></html>';
+
+const pricingHtmlMentioningChart =
+  '<!doctype html><html><body>' +
+  '<main>Pro components include Chart, Editor, Kanban.</main>' +
+  '</body></html>';
+
+const proComponentHtml =
+  '<!doctype html><html><body>' +
+  '<main>This component is only available in the Pro version of Flux. ' +
+  'Flux Pro component documentation here.</main>' +
+  '</body></html>';
+
+const freeComponentHtml =
+  '<!doctype html><html><body>' +
+  '<main>Documentation for the Button component (free tier).</main>' +
+  '</body></html>';
+
+describe('getBaseUrl', () => {
+  test('returns the v1 host when version="v1"', () => {
+    assert.strictEqual(getBaseUrl('v1'), 'https://v1.fluxui.dev');
+  });
+
+  test('returns the v2 host when version="v2"', () => {
+    assert.strictEqual(getBaseUrl('v2'), 'https://fluxui.dev');
+  });
+
+  test('defaults to the v2 host when version is undefined', () => {
+    assert.strictEqual(getBaseUrl(undefined), 'https://fluxui.dev');
+  });
+});
+
+describe('version routing', () => {
+  test('fetchFluxDocs("button", undefined, "v1") targets the v1 host', async () => {
+    const fetchSpy = mock.fn(async () => okText(freeComponentHtml));
+    const server = buildServer(fetchSpy);
+
+    await server.fetchFluxDocs('button', undefined, 'v1');
+
+    assert.strictEqual(fetchSpy.mock.callCount(), 1);
+    const url = fetchSpy.mock.calls[0].arguments[0];
+    assert.ok(
+      url.startsWith('https://v1.fluxui.dev'),
+      `expected v1 host, got ${url}`
+    );
+  });
+
+  test('listFluxLayouts("v1") returns the not-available message without fetching', async () => {
+    const fetchSpy = mock.fn(async () => okText('<html></html>'));
+    const server = buildServer(fetchSpy);
+
+    const result = await server.listFluxLayouts('v1');
+
+    assert.strictEqual(fetchSpy.mock.callCount(), 0);
+    assert.match(
+      result.content[0].text,
+      /layouts are not available in v1/i
+    );
+  });
+});
+
+describe('tier filtering on listFluxComponents', () => {
+  // Build a fetch impl that serves /components from one fixture and /pricing
+  // from another, so listFluxComponents + getProComponents can both succeed.
+  const tieredFetch = () =>
+    mock.fn(async (url) => {
+      if (url.endsWith('/pricing')) {
+        return okText(pricingHtmlMentioningChart);
+      }
+      if (url.endsWith('/components')) {
+        return okText(componentsListHtmlV2);
+      }
+      throw new Error(`unexpected fetch url in test: ${url}`);
+    });
+
+  test('tier="free" excludes Pro components and keeps free ones', async () => {
+    const server = buildServer(tieredFetch());
+
+    const result = await server.listFluxComponents('v2', 'free');
+    const text = result.content[0].text;
+
+    assert.match(text, /button/i);
+    assert.doesNotMatch(text, /chart/i);
+  });
+
+  test('tier="pro" keeps Pro components and excludes free ones', async () => {
+    const server = buildServer(tieredFetch());
+
+    const result = await server.listFluxComponents('v2', 'pro');
+    const text = result.content[0].text;
+
+    assert.match(text, /chart/i);
+    assert.doesNotMatch(text, /button/i);
+  });
+
+  test('v1 does not leak [Pro]/[Free] annotations or call /pricing', async () => {
+    // v1 had no Pro tier. The listing must not annotate, the tier arg is
+    // ignored, and /pricing must never be fetched on v1.
+    const fetchSpy = mock.fn(async (url) => {
+      if (url.endsWith('/pricing')) {
+        throw new Error('v1 must NEVER fetch /pricing');
+      }
+      return okText(componentsListHtmlV2);
+    });
+    const server = buildServer(fetchSpy);
+
+    const result = await server.listFluxComponents('v1', 'pro');
+    const text = result.content[0].text;
+
+    assert.doesNotMatch(text, /\[Pro\]/);
+    assert.doesNotMatch(text, /\[Free\]/);
+    assert.match(text, /not applicable on v1/i);
+    // Sanity: at most one fetch (the /components index), zero to /pricing.
+    const pricingCalls = fetchSpy.mock.calls.filter((c) =>
+      String(c.arguments[0]).endsWith('/pricing')
+    );
+    assert.strictEqual(pricingCalls.length, 0);
+  });
+});
+
+describe('Pro-component notice on fetchFluxDocs', () => {
+  test('prepends [NOTICE] when the page contains "Flux Pro component"', async () => {
+    const server = buildServer(mock.fn(async () => okText(proComponentHtml)));
+
+    const result = await server.fetchFluxDocs('chart', undefined, 'v2');
+    const text = result.content[0].text;
+
+    assert.ok(
+      text.startsWith('[NOTICE]'),
+      `expected text to start with [NOTICE], got: ${text.slice(0, 60)}`
+    );
+    assert.match(text, /Pro component/);
+  });
+
+  test('does not prepend [NOTICE] when the page is free', async () => {
+    const server = buildServer(mock.fn(async () => okText(freeComponentHtml)));
+
+    const result = await server.fetchFluxDocs('button', undefined, 'v2');
+    const text = result.content[0].text;
+
+    assert.doesNotMatch(text, /\[NOTICE\]/);
+  });
+});
+
+describe('getProComponents fallback', () => {
+  test('returns the hardcoded fallback Set when the fetch throws', async () => {
+    const server = buildServer(
+      mock.fn(async () => {
+        throw new Error('network down');
+      })
+    );
+
+    const result = await server.getProComponents();
+
+    assert.ok(result instanceof Set);
+    assert.ok(result.has('chart'), 'expected fallback to include "chart"');
+    assert.ok(result.has('editor'), 'expected fallback to include "editor"');
+    assert.ok(result.has('kanban'), 'expected fallback to include "kanban"');
+  });
+});

--- a/test/unit/tools.test.js
+++ b/test/unit/tools.test.js
@@ -25,17 +25,34 @@ describe('MCP Tool Schemas', () => {
       assert.ok(tool, 'fetch_flux_docs tool must be defined');
     });
 
-    test('has component, layout, search properties (all optional)', () => {
+    test('has component, layout, and version properties (all optional)', () => {
       assert.ok(tool.inputSchema.properties.component);
       assert.ok(tool.inputSchema.properties.layout);
-      assert.ok(tool.inputSchema.properties.search);
+      assert.ok(tool.inputSchema.properties.version);
       assert.strictEqual(tool.inputSchema.required, undefined);
     });
 
-    test('all three params are strings', () => {
+    test('component, layout, and version params are strings', () => {
       assert.strictEqual(tool.inputSchema.properties.component.type, 'string');
       assert.strictEqual(tool.inputSchema.properties.layout.type, 'string');
-      assert.strictEqual(tool.inputSchema.properties.search.type, 'string');
+      assert.strictEqual(tool.inputSchema.properties.version.type, 'string');
+    });
+
+    test('search property is preserved as a deprecated no-op (semver compat)', () => {
+      // Removing the arg outright would be a breaking change for 2.2.x clients.
+      // It is accepted-but-ignored at the handler level until 3.0.
+      assert.ok(tool.inputSchema.properties.search);
+      assert.match(
+        tool.inputSchema.properties.search.description,
+        /deprecated/i
+      );
+    });
+
+    test('version enum is exactly v1 and v2', () => {
+      assert.deepStrictEqual(
+        tool.inputSchema.properties.version.enum,
+        ['v1', 'v2']
+      );
     });
   });
 
@@ -46,8 +63,16 @@ describe('MCP Tool Schemas', () => {
       assert.ok(tool);
     });
 
-    test('takes no parameters', () => {
-      assert.strictEqual(Object.keys(tool.inputSchema.properties).length, 0);
+    test('has version and tier properties', () => {
+      assert.ok(tool.inputSchema.properties.version);
+      assert.ok(tool.inputSchema.properties.tier);
+    });
+
+    test('tier enum is exactly free, pro, all', () => {
+      assert.deepStrictEqual(
+        tool.inputSchema.properties.tier.enum,
+        ['free', 'pro', 'all']
+      );
     });
   });
 
@@ -58,8 +83,12 @@ describe('MCP Tool Schemas', () => {
       assert.ok(tool);
     });
 
-    test('takes no parameters', () => {
-      assert.strictEqual(Object.keys(tool.inputSchema.properties).length, 0);
+    test('has a version property', () => {
+      assert.ok(tool.inputSchema.properties.version);
+      assert.deepStrictEqual(
+        tool.inputSchema.properties.version.enum,
+        ['v1', 'v2']
+      );
     });
   });
 


### PR DESCRIPTION
## What this PR does

Additive 2.3.0 release. **No breaking changes** — all defaults preserve current 2.2.x behavior.

Closes the feature gap audited earlier: LLMs using this MCP could not tell that a Flux component was paywalled, and the server only spoke v2 even though `v1.fluxui.dev` still serves users on `livewire/flux:^1`.

## Changes

### Added
- Optional `version` argument (`'v1' | 'v2'`, default `'v2'`) on `fetch_flux_docs`, `list_flux_components`, `list_flux_layouts`. Routes the v1 case to `v1.fluxui.dev`. `list_flux_component_icons` stays version-independent (Heroicons are GitHub-sourced).
- Optional `tier` argument (`'free' | 'pro' | 'all'`, default `'all'`) on `list_flux_components`. On `'all'`, each entry is annotated `[Pro]` / `[Free]`. Ignored on v1 (v1 had no Pro tier).
- Pro-component detection — scrapes `/pricing` once per cache window with a hardcoded fallback set so the tier filter still works offline. `fetch_flux_docs` prepends a `[NOTICE] This is a Flux Pro component — requires a paid Flux license.` line when the page is paywalled (detection signal: the literal `Flux Pro component` marker present on every paid component page).
- Friendly "layouts are not available in v1" response on `list_flux_layouts({version:'v1'})` without making any HTTP request (Flux v1 has no `/layouts` route).

### Changed
- `list_flux_components` now fetches `/components` instead of `/docs` — same nav, one fewer hop.
- SSRF allowlist on the documentation fetcher widened to `fluxui.dev` + `v1.fluxui.dev`. The Heroicons GitHub allowlist is unchanged. Every other prior hardening guarantee (untrusted-content isolation, error-message sanitization, in-flight dedup, LRU cap, redirect allowlist, response-size caps) is preserved.
- Cache keys gain a `CACHE_SCHEMA_VERSION` prefix so a payload-shape change in a future minor will not silently serve stale data on the next upgrade.

### Deprecated
- `search` parameter on `fetch_flux_docs` — kept in the schema for backward compatibility with 2.2.x callers but accepted-and-ignored at the handler level. The previous line-based filter returned incoherent fragments. Scheduled for removal in 3.0.

## Why

Two real LLM failure modes were closing without this:
1. The LLM suggests a Pro component (Chart, Calendar, Editor, …) to a user who does not hold a Flux license → frustration, install, paywall hit. Now the LLM sees `[Pro]` in the listing and a `[NOTICE]` on the docs page and either suggests a free alternative or flags the cost upfront.
2. A user on `livewire/flux:^1` asks "show me the Button docs" and gets v2 docs that mention APIs that do not exist in their project. Now they pass `version: 'v1'` and get the right docs.

## Test plan

```
$ node --test test/**/*.test.js
ℹ tests 50
ℹ pass 50
ℹ fail 0
```

Baseline was 38/38 on `main`. Net delta is +12 new tests, zero regressions. New coverage includes:
- `getBaseUrl` (v1, v2, default).
- Version routing on `fetch_flux_docs` actually hits the v1 host when asked.
- `list_flux_layouts('v1')` returns the not-available message and makes **zero** fetch calls.
- `list_flux_components` with `tier='free'` excludes Chart; with `tier='pro'` excludes Button; on v1 leaks no `[Pro]`/`[Free]` annotations and never touches `/pricing`.
- `[NOTICE]` is prepended on Pro pages and absent on Free pages.
- `getProComponents()` gracefully falls back to the hardcoded set when the pricing fetch throws.
- Schema tests for the new `version` enum and the `tier` enum on `list_flux_components`.
- Schema test asserting the deprecated `search` arg description includes `deprecated`.

## Out of scope (deferred)

A structured props parser (`get_flux_component_props`) and cross-component fuzzy search were considered in the audit and explicitly deferred. They can land if a user files an issue asking for them.