### PR TITLE
fix(ci): Publish workflow idempotent on package.json version (republishes 2.3.0 as 2.3.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,22 @@ jobs:
           echo "version=$TAG" >> $GITHUB_OUTPUT
 
       - name: Update package version
-        run: npm version ${{ steps.get-latest-tag.outputs.version }} --no-git-tag-version
+        # Idempotent: if package.json already matches the tag (e.g. a contributor
+        # pre-bumped it in a PR), skip the npm-version call — `npm version $X`
+        # exits 1 with "Version not changed" when X equals the current value,
+        # which previously broke the publish gate on the v2.3.0 release.
+        # See CHANGELOG entry for 2.3.1 for the incident.
+        run: |
+          set -u
+          TARGET="${{ steps.get-latest-tag.outputs.version }}"
+          TARGET="${TARGET#v}"
+          CURRENT=$(node -p "require('./package.json').version")
+          if [ "$CURRENT" = "$TARGET" ]; then
+            echo "package.json already at $TARGET — skipping npm version"
+          else
+            echo "Bumping package.json from $CURRENT to $TARGET"
+            npm version "$TARGET" --no-git-tag-version
+          fi
 
       - name: Publish package
         run: npm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `livewire-flux-mcp` will be documented in this file.
 
+## 2.3.1 - 2026-05-21
+
+Republishes the v2.3.0 contents to npm. The v2.3.0 release (cut earlier today) merged cleanly but the Publish workflow failed at the `Update package version` step: that step ran `npm version 2.3.0 --no-git-tag-version`, and npm exits 1 with `Version not changed` when the value is unchanged. The 2.3.0 PR had pre-bumped `package.json` to `2.3.0`, so the bump-to-same-value tripped the gate and v2.3.0 never reached npm. The v2.3.0 tag is permanently burned by GitHub's Immutable Releases (same surface that burned v2.2.0).
+
+### Fixed
+
+* Publish workflow's `Update package version` step is now idempotent — it reads the current `package.json` version, compares it to the tag, and only invokes `npm version` on mismatch. Future contributors can pre-bump `package.json` in a PR without breaking the publish gate.
+
+### Changed
+
+* `package.json` version field aligned with the workflow's tag-driven contract (no longer pre-bumped in feature PRs).
+
 ## 2.3.0 - 2026-05-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "livewire-flux-mcp",
-  "version": "2.1.17",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "livewire-flux-mcp",
-      "version": "2.1.17",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livewire-flux-mcp",
-  "version": "2.3.0",
+  "version": "2.2.1",
   "description": "MCP server for Livewire Flux Components documentation",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## What broke

Publish workflow run for **v2.3.0** ([run 26219569201](https://github.com/leMaur/livewire-flux-mcp/actions/runs/26219569201)) failed at the `Update package version` step. The step ran `npm version 2.3.0 --no-git-tag-version`, and npm exits 1 with **`Version not changed`** when the requested version equals the current `package.json` value. The v2.3.0 PR (#51) pre-bumped `package.json` to `2.3.0`, so the bump-to-same-value tripped the gate and v2.3.0 never reached the registry.

The v2.3.0 tag is now permanently burned by GitHub's Immutable Releases (same surface that burned v2.2.0 last week).

## What this PR does

### Fixed
- `.github/workflows/publish.yml` `Update package version` step is **idempotent**: pre-reads the current `package.json` version with `node -p`, strips any leading `v` from the tag, and only runs `npm version $TARGET` on mismatch. Defensive `set -u` for unset-variable typo defense. The match-path skips the call and logs a one-line "already at $TARGET" notice.

### Changed
- `package.json` version reverted `2.3.0` → `2.2.1` (matches last npm-published version) to realign the repo with the workflow's tag-driven contract.
- `package-lock.json` `version` and `packages[""].version` fields realigned to `2.2.1` (dependency graph is unchanged).

### Documented
- `CHANGELOG.md` gets a `2.3.1` entry above the existing `2.3.0` entry. Same convention used for the v2.2.0 → v2.2.1 supersession.

## Why this fix shape

Three alternatives considered and rejected:
1. **Recreate the v2.3.0 tag** — blocked by GitHub Immutable Releases (proven 2026-05-20 saga).
2. **Use `npm version $TARGET --allow-same-version`** — would have worked but hides intent. The explicit idempotent check is observable in the log and survives a future `npm` flag change.
3. **Remove the `npm version` step entirely** — would require contributors to manually bump `package.json` per release. Worse contract.

The idempotent step is the cheapest durable fix and codifies the workflow's existing implicit contract ("tag drives version").

## Local verification

```bash
# Match branch — should skip
TARGET=2.3.0; CURRENT=2.3.0; [ "$CURRENT" = "$TARGET" ] && echo "would skip ✓"

# Mismatch branch — should bump
TARGET=2.3.1; CURRENT=2.2.1; [ "$CURRENT" = "$TARGET" ] || \
  echo "would run: npm version $TARGET --no-git-tag-version ✓"
```

Both branches confirmed locally before push.

## Test plan
- `npm test` → 50/50 pass (unchanged from main).
- `test`, `Analyze (actions)`, `Analyze (javascript-typescript)`, `CodeQL` should all gate green on this PR.
- After merge: cut `v2.3.1` tag → Publish workflow exercises the **mismatch path** (package.json `2.2.1` → tag `2.3.1`) → npm gets `livewire-flux-mcp@2.3.1` with provenance + sigstore.

## Out of scope
- No change to the `Publishing` GitHub Environment policy.
- No change to `main` branch protection.
- No PAT introduced.
- No other workflow file modified.