### PR TITLE
ci: set persist-credentials: false on checkout steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6 (resolved 2026-05-20)
+        with:
+          persist-credentials: false
 
       - name: Install node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6 (resolved 2026-05-20)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6 (resolved 2026-05-20)
+        with:
+          persist-credentials: false
 
       - name: Install node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6 (resolved 2026-05-20)

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6 (resolved 2026-05-20)
         with:
           ref: main
+          persist-credentials: false
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1 (resolved 2026-05-20)


### PR DESCRIPTION
## What

Set `persist-credentials: false` on every `actions/checkout` step across the CI and release workflows.

## Why

By default `actions/checkout` writes the job token into the workspace `.git/config` as an auth header. Persisting it only widens the attack surface: any later step in the same job (a compromised action, or a malicious transitive dependency pulled in during install) could read the token from disk. Setting `persist-credentials: false` keeps it out of the checkout and shrinks the blast radius.

## Scope

Now includes the release changelog workflow. That job pushes its branch via `create-pull-request`, which authenticates with the `token` it is given as an input rather than the credentials persisted by checkout, so `persist-credentials: false` is the recommended setup there (it also ensures the action's own token, not the one baked into git config by checkout, is used for the push).
