### PR TITLE
fix: source layout names from the site nav when /layouts 404s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ The project consists of a single main file (`index.js`) that implements:
    - Optional `version` parameter (`'v1' | 'v2'`, default `'v2'`)
    - Returns layouts with names and paths
    - On v1, returns a "not available" notice without making any HTTP request
+   - Sources names via `collectLayoutLinks()`: tries `/layouts` first, then falls back to
+     `/components`. The `/layouts` index 404s upstream as of 2026-08 while `/layouts/{name}`
+     still resolves, and layout links appear in the site-wide nav on every page. Keeping the
+     index first means the tool repairs itself if Flux restores it.
 
 4. **list_flux_component_icons**:
    - Optional `variant` parameter (`outline | solid | mini | micro`)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The server provides four MCP tools:
 3. **`list_flux_layouts`** - Lists all available Flux layouts
    - `version` (optional): `'v1'` or `'v2'` (default `'v2'`). On v1 the tool returns a brief "layouts are not available in v1" notice without making any HTTP request.
    - Provides layout names and their documentation paths
+   - Layout names are read from `fluxui.dev/layouts`, falling back to the site-wide navigation on `fluxui.dev/components` when that index is unavailable — the individual `/layouts/{name}` pages are unaffected either way
 
 4. **`list_flux_component_icons`** - Lists all available Heroicons for flux:icon component
    - `variant` (optional): Filter by icon variant (`outline`, `solid`, `mini`, `micro`)

--- a/index.js
+++ b/index.js
@@ -80,6 +80,47 @@ export function getBaseUrl(version) {
   return version === 'v1' ? 'https://v1.fluxui.dev' : 'https://fluxui.dev';
 }
 
+// Anchor text in the site nav sometimes carries a description on following lines
+// ("Sidebar\n\nCreate primary or secondary navigation sidebars"). Keep the first
+// non-empty line, which is the name.
+function normalizeLinkLabel(text) {
+  const firstLine = text
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  return (firstLine ?? '').replace(/\s+/g, ' ').trim();
+}
+
+// Pull `/layouts/{name}` links out of any Flux page. Layout links live in the global
+// nav, so any page carries them — which is what makes the fallback below possible.
+function parseLayoutLinks(html, baseUrl) {
+  const $ = cheerio.load(html);
+  const absolutePrefix = `${baseUrl}/layouts/`;
+  const links = [];
+
+  $('a').each((i, el) => {
+    const href = $(el).attr('href');
+    if (!href) return;
+
+    let path = null;
+    if (href.startsWith(absolutePrefix)) {
+      path = href.slice(absolutePrefix.length);
+    } else if (href.startsWith('/layouts/')) {
+      path = href.slice('/layouts/'.length);
+    }
+    if (!path) return;
+
+    path = path.split(/[#?]/)[0].replace(/\/+$/, '');
+    const name = normalizeLinkLabel($(el).text());
+    if (!path || !name || links.some((link) => link.path === path)) return;
+
+    links.push({ name, href, path });
+  });
+
+  return links;
+}
+
 function formatFluxComponentLabel(slug) {
   return slug
     .split('-')
@@ -545,6 +586,41 @@ export class FluxDocumentationServer {
     });
   }
 
+  // `fluxui.dev/layouts` was an index page listing every layout. It now 404s, while the
+  // individual `/layouts/{name}` pages still resolve — so scraping the index alone leaves
+  // the tool permanently broken. Layout links also appear in the site-wide nav rendered on
+  // every page, so fall back to a page that is known to respond. The index is still tried
+  // first, which means this repairs itself if Flux brings it back.
+  async collectLayoutLinks(baseUrl) {
+    const sources = [`${baseUrl}/layouts`, `${baseUrl}/components`];
+    let lastStatus = null;
+
+    for (const url of sources) {
+      const response = await this.fetchWithTimeout(url, { allowedHosts: FLUX_ALLOWED_HOSTS });
+
+      if (!response.ok) {
+        lastStatus = response.status;
+        continue;
+      }
+
+      const html = await response.text();
+      if (typeof html !== 'string') {
+        throw new Error(`Invalid HTML response body for ${url}`);
+      }
+
+      const links = parseLayoutLinks(html, baseUrl);
+      if (links.length > 0) {
+        return links;
+      }
+    }
+
+    throw new Error(
+      lastStatus === null
+        ? 'No layouts found on the Flux documentation site'
+        : `No layouts found (layout index returned HTTP ${lastStatus})`
+    );
+  }
+
   async listFluxLayouts(version) {
     try {
       if (version === 'v1') {
@@ -555,41 +631,10 @@ export class FluxDocumentationServer {
 
       const normalizedVersion = version || 'v2';
       const baseUrl = getBaseUrl(version);
-      const layoutPrefix = `${baseUrl}/layouts/`;
       const cacheKey = `layouts:${CACHE_SCHEMA_VERSION}:${normalizedVersion}`;
 
       return await this.withSingleFlight(cacheKey, async () => {
-        const response = await this.fetchWithTimeout(`${baseUrl}/layouts`, { allowedHosts: FLUX_ALLOWED_HOSTS });
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const html = await response.text();
-        if (typeof html !== 'string') {
-          throw new Error(`Invalid HTML response body for ${baseUrl}/layouts`);
-        }
-
-        const $ = cheerio.load(html);
-        const links = [];
-        $('a').each((i, el) => {
-          const href = $(el).attr('href');
-          const text = $(el).text().trim();
-          let path = null;
-
-          if (href && href.startsWith(layoutPrefix)) {
-            path = href.slice(layoutPrefix.length);
-          } else if (href && href.startsWith('/layouts/')) {
-            path = href.slice('/layouts/'.length);
-          }
-
-          if (href && text && path && !links.some(link => link.path === path)) {
-            links.push({
-              name: text,
-              href,
-              path,
-            });
-          }
-        });
+        const links = await this.collectLayoutLinks(baseUrl);
 
         const layoutsList = links
           .map(link => `- ${link.name} (${link.path})`)

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -157,6 +157,93 @@ describe('FluxDocumentationServer integration', () => {
       assert.match(result.content[0].text, /Header/);
       assert.match(result.content[0].text, /Sidebar/);
     });
+
+    test('does not hit the fallback when the index works', async () => {
+      const fetchSpy = mock.fn(async () =>
+        okText('<a href="/layouts/header">Header</a>')
+      );
+      const server = buildServer(fetchSpy);
+
+      await server.listFluxLayouts();
+
+      assert.strictEqual(fetchSpy.mock.callCount(), 1);
+    });
+
+    // fluxui.dev/layouts started returning 404 while /layouts/{name} kept working.
+    // Layout links live in the site-wide nav, so any responding page can supply them.
+    test('falls back to the components page when the index 404s', async () => {
+      const fetchSpy = mock.fn(async (url) =>
+        url === 'https://fluxui.dev/layouts'
+          ? httpError(404)
+          : okText(
+            '<a href="/layouts/header">Header</a>' +
+            '<a href="/layouts/sidebar">Sidebar</a>'
+          )
+      );
+      const server = buildServer(fetchSpy);
+
+      const result = await server.listFluxLayouts();
+
+      assert.deepStrictEqual(
+        fetchSpy.mock.calls.map((call) => call.arguments[0]),
+        ['https://fluxui.dev/layouts', 'https://fluxui.dev/components']
+      );
+      assert.match(result.content[0].text, /- Header \(header\)/);
+      assert.match(result.content[0].text, /- Sidebar \(sidebar\)/);
+    });
+
+    test('falls back when the index responds but carries no layout links', async () => {
+      const fetchSpy = mock.fn(async (url) =>
+        url === 'https://fluxui.dev/layouts'
+          ? okText('<a href="/components/button">Button</a>')
+          : okText('<a href="/layouts/sidebar">Sidebar</a>')
+      );
+      const server = buildServer(fetchSpy);
+
+      const result = await server.listFluxLayouts();
+
+      assert.strictEqual(fetchSpy.mock.callCount(), 2);
+      assert.match(result.content[0].text, /Sidebar/);
+    });
+
+    test('keeps only the layout name when the nav anchor carries a description', async () => {
+      const fetchSpy = mock.fn(async () =>
+        okText(
+          '<a href="/layouts/sidebar">Sidebar \n\n  \n\n Create primary or secondary navigation sidebars</a>'
+        )
+      );
+      const server = buildServer(fetchSpy);
+
+      const result = await server.listFluxLayouts();
+
+      assert.match(result.content[0].text, /- Sidebar \(sidebar\)/);
+      assert.ok(!result.content[0].text.includes('Create primary'));
+    });
+
+    test('ignores query strings, fragments and trailing slashes when deduping', async () => {
+      const fetchSpy = mock.fn(async () =>
+        okText(
+          '<a href="/layouts/header">Header</a>' +
+          '<a href="/layouts/header/">Header again</a>' +
+          '<a href="/layouts/header#reference">Header anchor</a>' +
+          '<a href="/layouts/header?x=1">Header query</a>'
+        )
+      );
+      const server = buildServer(fetchSpy);
+
+      const result = await server.listFluxLayouts();
+
+      assert.strictEqual((result.content[0].text.match(/^- /gm) ?? []).length, 1);
+    });
+
+    test('reports a clear error when neither source yields layouts', async () => {
+      const server = buildServer(mock.fn(async () => httpError(404)));
+
+      await assert.rejects(
+        () => server.listFluxLayouts(),
+        /No layouts found \(layout index returned HTTP 404\)/
+      );
+    });
   });
 
   describe('listFluxComponentIcons', () => {


### PR DESCRIPTION
## Problem

`https://fluxui.dev/layouts` used to serve an index of every layout. It now returns **404**, while the individual `/layouts/{name}` pages still resolve:

```
https://fluxui.dev/layouts          404
https://fluxui.dev/layouts/header   200
https://fluxui.dev/layouts/sidebar  200
```

`list_flux_layouts` scraped only that index, so every call failed:

```
Failed to list layouts: HTTP error! status: 404
```

## Fix

Layout links are also rendered in the site-wide navigation that appears on every documentation page — verified against `/layouts/header`, `/components/button` and `/docs/installation`, all three of which carry both layout links.

`collectLayoutLinks()` tries `/layouts` first and falls back to `/components`. Keeping the index first means the tool repairs itself with no release if the page is restored.

Two parsing issues showed up in the real markup and are handled:

- Nav anchors carry a description on later lines — `Sidebar` followed by `Create primary or secondary navigation sidebars`. Only the first non-empty line is kept as the name.
- Hrefs vary by fragment, query string and trailing slash. Paths are normalised before deduplication, so `header`, `header/`, `header#reference` and `header?x=1` collapse to one entry.

The failure message now names the index status rather than surfacing a bare `HTTP error! status: 404`.

## Verification

Live, against fluxui.dev:

```
Available Flux Layouts:

- Header (header)
- Sidebar (sidebar)
```

`fetch_flux_docs` with `layout: "sidebar"` resolves, and v1 still short-circuits with its notice and no HTTP request.

Six tests added: no fallback request when the index responds, fallback on 404 (asserting the exact URL sequence), fallback when the index responds without layout links, description stripping, fragment/query/slash deduplication, and the both-sources-fail message. Suite is green.

## Notes

Independent of the other two open PRs and can merge in any order.
