### PR TITLE
feat: ship Flux AI guideline, skill and subagent with an installer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ This is an MCP (Model Context Protocol) server that provides access to Livewire 
 - `npm install` - Install dependencies
 - `npm start` - Start the MCP server
 - `npm run dev` - Start the server with file watching for development
+- `npm test` - Run the test suite (Node built-in runner)
 - `npx .` - Run the server directly with npx
+- `node index.js install --path <dir> --dry-run` - Preview the AI-artifact installer
 
 ## Architecture
 
@@ -50,6 +52,30 @@ The project consists of a single main file (`index.js`) that implements:
    - Optional `variant` parameter (`outline | solid | mini | micro`)
    - Optional `search` parameter to filter icon names
    - Version-independent (Heroicons are not part of Flux versioning)
+
+## AI Artifacts & Installer
+
+`resources/` holds the guidance shipped to consumers, laid out to match Laravel Boost's own
+convention:
+
+- `resources/boost/skills/fluxui-development/SKILL.md` — on-demand skill. The frontmatter
+  `name` **must stay `fluxui-development`**: that string is the override key Boost uses, so
+  changing it silently hands control back to Boost's bundled skill (which routes Flux lookups
+  to `search-docs`). A unit test asserts this.
+- `resources/boost/guidelines/core.blade.php` — always-loaded guideline block.
+- `resources/agents/flux-ui-builder.md` — Claude Code subagent.
+
+`install.js` copies them into a consumer project (`.ai/skills/…`, `.ai/guidelines/fluxui-{free,pro}/…`,
+`.claude/agents/…`). It is imported lazily from `index.js` only when `process.argv[2] === 'install'`,
+so the stdio server path is unaffected — a bare invocation must always produce a clean stdio server
+with nothing on stdout.
+
+Boost only auto-discovers third-party guidelines/skills from **Composer** packages, so an npm
+package can never be picked up automatically; the installer writes to Boost's documented *custom*
+guideline/skill paths instead. Guideline writes merge behind `{{-- livewire-flux-mcp:begin --}}`
+markers and never clobber existing content; whole-file artifacts carry
+`<!-- livewire-flux-mcp:managed -->` so a re-run may replace them while user-authored files are
+refused without `--force`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,42 @@ are ignored in untrusted projects.
 
 </details>
 
+## AI Guidelines & Skills
+
+Registering the server tells your agent the tools *exist*. It does not tell it *when to reach
+for them* — and in a Laravel Boost project it actively will not, because Boost ships a
+`fluxui-development` skill that sends Flux lookups to its own `search-docs` tool and carries a
+hardcoded component list. This package ships guidance that fixes that:
+
+```shell
+npx livewire-flux-mcp install
+```
+
+| File | What it is |
+| --- | --- |
+| `.ai/skills/fluxui-development/SKILL.md` | On-demand skill: the Flux workflow, driven by this server's tools. **Replaces Boost's bundled skill of the same name.** |
+| `.ai/guidelines/fluxui-{free,pro}/core.blade.php` | Always-loaded guideline establishing that Flux questions are resolved through `flux-docs`. |
+| `.claude/agents/flux-ui-builder.md` | A Claude Code subagent that builds Flux interfaces and looks every component up before writing markup. |
+
+The installer detects what applies: `livewire/flux-pro` in `composer.json` selects the `fluxui-pro`
+guideline key, `livewire/flux` selects `fluxui-free`, and a `.claude/` directory adds the subagent.
+Restrict it with `--boost` or `--claude`, point it elsewhere with `--path <dir>`, or preview with
+`--dry-run`. Afterwards run `php artisan boost:update` so Boost picks the files up.
+
+**On overwriting.** The skill is a deliberate replacement — Boost resolves custom skills last and
+keys them on the frontmatter `name`, so `fluxui-development` has to match for the override to
+land. The guideline is never clobbered: an existing file at that path, or the guideline shipped
+inside the Flux package itself, is preserved below our block, which is delimited by
+`{{-- livewire-flux-mcp:begin --}}` markers so re-running only refreshes that section. Any file
+the installer did not write is left alone unless you pass `--force`.
+
+To undo, delete the installed files and run `php artisan boost:update` — Boost restores its own
+versions.
+
+> Laravel Boost only auto-discovers guidelines and skills from Composer packages, so an npm
+> package cannot register them automatically. This installer writes to the paths Boost documents
+> for custom guidelines and skills, which is why it works and survives `boost:update`.
+
 ## Available MCP Tools
 
 The server provides four MCP tools:

--- a/index.js
+++ b/index.js
@@ -765,6 +765,13 @@ const invokedAsMain =
   import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
 
 if (invokedAsMain) {
-  const server = new FluxDocumentationServer();
-  server.run().catch(console.error);
+  // Only `install` is special-cased. Anything else starts the stdio server, so an MCP
+  // client passing unexpected arguments still gets a working server rather than a CLI error.
+  if (process.argv[2] === 'install') {
+    const { runInstall } = await import('./install.js');
+    process.exitCode = runInstall(process.argv.slice(3));
+  } else {
+    const server = new FluxDocumentationServer();
+    server.run().catch(console.error);
+  }
 }

--- a/install.js
+++ b/install.js
@@ -1,0 +1,483 @@
+// Installer for the AI guidelines, skill and subagent shipped with this package.
+//
+// Laravel Boost only auto-discovers third-party guidelines and skills from *Composer*
+// packages (it reads composer.json, then looks in vendor/{pkg}/resources/boost/…), so an
+// npm package can never be picked up automatically. Instead we write into the paths Boost
+// documents for *custom* guidelines and skills, which take precedence over the bundled ones:
+//
+//   .ai/skills/fluxui-development/SKILL.md        overrides Boost's fluxui-development skill
+//   .ai/guidelines/fluxui-{free,pro}/core.blade.php   overrides the matching Flux guideline
+//
+// The skill override is deliberate: Boost's bundled version routes Flux lookups to its own
+// `search-docs` tool and carries a hardcoded component list, so without replacing it this
+// MCP server is never consulted.
+//
+// This module is imported lazily by index.js, only for `livewire-flux-mcp install`, so the
+// stdio server path never pays for it.
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+const PACKAGE_ROOT = dirname(fileURLToPath(import.meta.url));
+
+// Blade comment: invisible once Boost renders the guideline.
+export const GUIDELINE_MARKER_BEGIN = '{{-- livewire-flux-mcp:begin --}}';
+export const GUIDELINE_MARKER_END = '{{-- livewire-flux-mcp:end --}}';
+// HTML comment: marks a whole file as owned by this installer, so a re-run may safely
+// replace it while a file the user wrote themselves is left alone. Matched on its own line
+// so that merely quoting the marker in prose does not transfer ownership.
+export const MANAGED_MARKER = '<!-- livewire-flux-mcp:managed -->';
+const MANAGED_MARKER_LINE = /^[ \t]*<!-- livewire-flux-mcp:managed -->[ \t]*$/m;
+
+const SOURCES = {
+  guideline: join(PACKAGE_ROOT, 'resources', 'boost', 'guidelines', 'core.blade.php'),
+  skill: join(PACKAGE_ROOT, 'resources', 'boost', 'skills', 'fluxui-development', 'SKILL.md'),
+  agent: join(PACKAGE_ROOT, 'resources', 'agents', 'flux-ui-builder.md'),
+};
+
+const USAGE = `livewire-flux-mcp install — install the Flux AI guideline, skill and subagent
+
+Usage:
+  npx livewire-flux-mcp install [options]
+
+Options:
+  --path <dir>   Target project directory (default: current directory)
+  --boost        Install the Boost guideline + skill (default: when composer.json exists)
+  --claude       Install the Claude Code subagent (default: when .claude/ exists)
+  --dry-run      Report what would change without writing anything
+  --force        Replace an existing file this installer does not manage
+  -h, --help     Show this message
+
+Writes:
+  .ai/skills/fluxui-development/SKILL.md          (replaces Boost's bundled skill)
+  .ai/guidelines/fluxui-{free,pro}/core.blade.php (merged, never clobbered)
+  .claude/agents/flux-ui-builder.md
+`;
+
+/** Raised when a destination cannot be written safely. Surfaced as a refusal, never a crash. */
+export class InstallRefusal extends Error {}
+
+export function parseInstallArgs(argv = []) {
+  const options = {
+    path: null,
+    boost: false,
+    claude: false,
+    dryRun: false,
+    force: false,
+    help: false,
+    unknown: [],
+    errors: [],
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--path': {
+        const value = argv[i + 1];
+        // Without this guard `--path --dry-run` would silently consume the next flag and
+        // install into a directory literally named "--dry-run".
+        if (value === undefined || value.startsWith('-')) {
+          options.errors.push('--path requires a directory argument');
+        } else {
+          options.path = value;
+          i += 1;
+        }
+        break;
+      }
+      case '--boost':
+        options.boost = true;
+        break;
+      case '--claude':
+        options.claude = true;
+        break;
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--force':
+        options.force = true;
+        break;
+      case '-h':
+      case '--help':
+        options.help = true;
+        break;
+      default:
+        if (arg.startsWith('--path=')) {
+          const value = arg.slice('--path='.length);
+          if (value === '') {
+            options.errors.push('--path requires a directory argument');
+          } else {
+            options.path = value;
+          }
+        } else {
+          options.unknown.push(arg);
+        }
+    }
+  }
+
+  return options;
+}
+
+function readJsonIfPresent(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Which Flux guideline key applies, mirroring Boost's PackageRegistry:
+ *   livewire/flux     -> fluxui-free
+ *   livewire/flux-pro -> fluxui-pro
+ * Boost excludes the free package when the pro one is present, so pro wins.
+ * Returns null when neither is required, in which case we install both (only the one
+ * matching the installed package is ever read).
+ */
+export function detectFluxEdition(targetDir) {
+  const composer = readJsonIfPresent(join(targetDir, 'composer.json'));
+  if (!composer) return null;
+
+  const required = {
+    ...(composer.require ?? {}),
+    ...(composer['require-dev'] ?? {}),
+  };
+
+  if (Object.hasOwn(required, 'livewire/flux-pro')) return 'fluxui-pro';
+  if (Object.hasOwn(required, 'livewire/flux')) return 'fluxui-free';
+  return null;
+}
+
+/**
+ * Flux ships its own core guideline inside its Composer package; Boost resolves it from
+ * there because Flux is first-party. Overriding without merging would delete it, so find
+ * it and keep it.
+ */
+export function findVendorGuideline(targetDir, edition) {
+  const vendorPackage = edition === 'fluxui-pro' ? 'livewire/flux-pro' : 'livewire/flux';
+  const base = join(targetDir, 'vendor', ...vendorPackage.split('/'), 'resources', 'boost', 'guidelines');
+
+  for (const ext of ['.blade.php', '.md']) {
+    const candidate = join(base, `core${ext}`);
+    if (existsSync(candidate)) {
+      return { path: candidate, content: readFileSync(candidate, 'utf-8') };
+    }
+  }
+
+  return null;
+}
+
+function indexesOf(haystack, needle) {
+  const found = [];
+  let from = 0;
+  for (;;) {
+    const at = haystack.indexOf(needle, from);
+    if (at === -1) return found;
+    found.push(at);
+    from = at + needle.length;
+  }
+}
+
+/**
+ * Build the guideline file: our block, delimited by markers, with everything else preserved
+ * byte for byte.
+ *
+ * - No markers present: prepend our block, leave the rest untouched.
+ * - Exactly one well-formed pair: replace that span *in place*, so surrounding content keeps
+ *   its position and whitespace.
+ * - Anything else (partial, duplicated or out-of-order markers): refuse, because we cannot
+ *   tell which span is ours. `force` falls back to replacing first-begin..last-end.
+ */
+export function composeGuideline(block, existingContent = '', { force = false } = {}) {
+  const ours = `${GUIDELINE_MARKER_BEGIN}\n${block.trim()}\n${GUIDELINE_MARKER_END}`;
+  const existing = existingContent ?? '';
+
+  if (existing.trim() === '') return `${ours}\n`;
+
+  const begins = indexesOf(existing, GUIDELINE_MARKER_BEGIN);
+  const ends = indexesOf(existing, GUIDELINE_MARKER_END);
+
+  if (begins.length === 0 && ends.length === 0) {
+    return `${ours}\n\n${existing}`;
+  }
+
+  const wellFormed = begins.length === 1 && ends.length === 1 && ends[0] > begins[0];
+
+  if (!wellFormed && !force) {
+    throw new InstallRefusal(
+      'the existing guideline has malformed livewire-flux-mcp markers ' +
+      `(${begins.length} begin, ${ends.length} end) — fix or remove them, or re-run with --force`
+    );
+  }
+
+  const start = begins.length > 0 ? begins[0] : ends[0];
+  const stop = ends.length > 0
+    ? ends[ends.length - 1] + GUIDELINE_MARKER_END.length
+    : begins[begins.length - 1] + GUIDELINE_MARKER_BEGIN.length;
+
+  return existing.slice(0, start) + ours + existing.slice(Math.max(start, stop));
+}
+
+/**
+ * Refuse to write anywhere that resolves outside the project. Walks up to the nearest
+ * existing ancestor so a symlinked `.ai` or `.claude` is caught before anything is written.
+ */
+function assertWithinProject(targetDir, destination) {
+  let probe = destination;
+  while (!existsSync(probe) && dirname(probe) !== probe) {
+    probe = dirname(probe);
+  }
+
+  const realProject = realpathSync(targetDir);
+  const realProbe = realpathSync(probe);
+
+  if (realProbe !== realProject && !realProbe.startsWith(realProject + sep)) {
+    throw new InstallRefusal(
+      `resolves outside the project (${realProbe}) — refusing to follow it`
+    );
+  }
+}
+
+function isOwnedByInstaller(contents) {
+  return MANAGED_MARKER_LINE.test(contents);
+}
+
+function planFullFileWrite({ targetDir, source, destination, force }) {
+  const desired = readFileSync(source, 'utf-8');
+  assertWithinProject(targetDir, destination);
+
+  if (!existsSync(destination)) {
+    return { action: 'create', destination, content: desired, ownership: 'absent' };
+  }
+
+  if (lstatSync(destination).isDirectory()) {
+    throw new InstallRefusal('a directory already exists at this path');
+  }
+
+  const current = readFileSync(destination, 'utf-8');
+  if (current === desired) {
+    return { action: 'unchanged', destination, content: desired, ownership: 'identical' };
+  }
+
+  // Only replace files this installer wrote, unless the user insists.
+  if (!isOwnedByInstaller(current) && !force) {
+    throw new InstallRefusal(
+      'file already exists and was not created by this installer (use --force to replace it)'
+    );
+  }
+
+  return { action: 'update', destination, content: desired, ownership: 'managed' };
+}
+
+function planGuidelineWrite({ targetDir, edition, force }) {
+  const block = readFileSync(SOURCES.guideline, 'utf-8');
+  const destination = join(targetDir, '.ai', 'guidelines', edition, 'core.blade.php');
+  assertWithinProject(targetDir, destination);
+
+  let base = '';
+  let mergedFrom = null;
+
+  if (existsSync(destination)) {
+    if (lstatSync(destination).isDirectory()) {
+      throw new InstallRefusal('a directory already exists at this path');
+    }
+    base = readFileSync(destination, 'utf-8');
+    mergedFrom = 'existing';
+  } else {
+    const vendor = findVendorGuideline(targetDir, edition);
+    if (vendor) {
+      base = vendor.content;
+      mergedFrom = relative(targetDir, vendor.path);
+    }
+  }
+
+  const content = composeGuideline(block, base, { force });
+
+  if (existsSync(destination) && base === content) {
+    return { action: 'unchanged', destination, content, mergedFrom };
+  }
+
+  return {
+    action: existsSync(destination) ? 'update' : 'create',
+    destination,
+    content,
+    mergedFrom,
+  };
+}
+
+function attempt(label, fn) {
+  try {
+    return { label, ...fn() };
+  } catch (error) {
+    if (error instanceof InstallRefusal) {
+      return { label, action: 'refused', reason: error.message };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Decide every file operation without touching disk. Exported so tests (and --dry-run)
+ * can assert the plan directly.
+ */
+export function planInstall(options = {}) {
+  const targetDir = resolve(options.path ?? process.cwd());
+  const explicit = options.boost || options.claude;
+
+  const wantsBoost = options.boost || (!explicit && existsSync(join(targetDir, 'composer.json')));
+  const wantsClaude = options.claude || (!explicit && existsSync(join(targetDir, '.claude')));
+
+  // Nothing recognisable: still install the Boost-shaped artifacts, since `.ai/` is the
+  // documented home for custom guidelines and skills.
+  const boost = wantsBoost || (!wantsBoost && !wantsClaude);
+
+  const steps = [];
+  const edition = detectFluxEdition(targetDir);
+
+  if (boost) {
+    steps.push(attempt('skill', () => planFullFileWrite({
+      targetDir,
+      source: SOURCES.skill,
+      destination: join(targetDir, '.ai', 'skills', 'fluxui-development', 'SKILL.md'),
+      force: options.force,
+    })));
+
+    // With neither Flux package required we cannot tell which key Boost will read, so
+    // write both. Boost only ever loads the one matching the installed package.
+    const editions = edition ? [edition] : ['fluxui-free', 'fluxui-pro'];
+    for (const key of editions) {
+      steps.push(attempt(`guideline (${key})`, () => planGuidelineWrite({
+        targetDir,
+        edition: key,
+        force: options.force,
+      })));
+    }
+  }
+
+  if (wantsClaude) {
+    steps.push(attempt('subagent', () => planFullFileWrite({
+      targetDir,
+      source: SOURCES.agent,
+      destination: join(targetDir, '.claude', 'agents', 'flux-ui-builder.md'),
+      force: options.force,
+    })));
+  }
+
+  return { targetDir, edition, boost, claude: wantsClaude, steps };
+}
+
+/**
+ * Re-check between planning and writing. The window is small, but it is the difference
+ * between "we decided this file was ours" and "this file is still ours".
+ */
+function stillSafeToWrite(step, force) {
+  if (step.ownership === 'managed' || step.ownership === undefined) return true;
+  if (!existsSync(step.destination)) return true;
+  if (force) return true;
+
+  const current = readFileSync(step.destination, 'utf-8');
+  return current === step.content || isOwnedByInstaller(current);
+}
+
+export function runInstall(argv = [], { log = console.log, cwd } = {}) {
+  const options = parseInstallArgs(argv);
+
+  if (options.errors.length > 0) {
+    log(`${options.errors[0]}\n`);
+    log(USAGE);
+    return 1;
+  }
+
+  if (options.unknown.length > 0) {
+    log(`Unknown option: ${options.unknown[0]}\n`);
+    log(USAGE);
+    return 1;
+  }
+
+  if (options.help) {
+    log(USAGE);
+    return 0;
+  }
+
+  const targetPath = options.path ?? cwd ?? process.cwd();
+  const resolvedTarget = resolve(targetPath);
+
+  if (existsSync(resolvedTarget) && !statSync(resolvedTarget).isDirectory()) {
+    log(`Not a directory: ${resolvedTarget}`);
+    return 1;
+  }
+  if (!existsSync(resolvedTarget)) {
+    log(`No such directory: ${resolvedTarget}`);
+    return 1;
+  }
+
+  const plan = planInstall({ ...options, path: resolvedTarget });
+  const { targetDir, edition, steps } = plan;
+
+  log(`livewire-flux-mcp install${options.dryRun ? ' (dry run)' : ''}`);
+  log(`  project: ${targetDir}`);
+  log(`  flux edition: ${edition ?? 'not detected — installing both guideline keys'}`);
+  log('');
+
+  const refused = steps.filter((step) => step.action === 'refused');
+
+  // Fail before writing anything: a partially installed project is worse than none.
+  if (refused.length > 0) {
+    for (const step of steps) {
+      const shown = step.destination ? relative(targetDir, step.destination) : step.label;
+      if (step.action === 'refused') {
+        log(`  ✗ ${step.label} — ${step.reason}`);
+      } else {
+        log(`  · ${shown} (${step.action}, not attempted)`);
+      }
+    }
+    log('');
+    log('Nothing was written. Resolve the entries marked ✗, or re-run with --force.');
+    return 1;
+  }
+
+  for (const step of steps) {
+    const shown = relative(targetDir, step.destination) || step.destination;
+
+    if (step.action === 'unchanged') {
+      log(`  = ${shown} (already up to date)`);
+      continue;
+    }
+
+    const suffix = step.mergedFrom ? `, merged with ${step.mergedFrom}` : '';
+    log(`  ${options.dryRun ? '·' : '✔'} ${shown} (${step.action}${suffix})`);
+
+    if (options.dryRun) continue;
+
+    if (!stillSafeToWrite(step, options.force)) {
+      log(`  ✗ ${shown} changed on disk since planning — skipped`);
+      return 1;
+    }
+
+    mkdirSync(dirname(step.destination), { recursive: true });
+    writeFileSync(step.destination, step.content, 'utf-8');
+  }
+
+  log('');
+
+  if (options.dryRun) {
+    log('Dry run — no files were written.');
+    return 0;
+  }
+
+  if (plan.boost) {
+    log('Next: run `php artisan boost:update` so Boost picks up the guideline and skill.');
+  }
+
+  return 0;
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "homepage": "https://github.com/leMaur/livewire-flux-mcp#readme",
   "files": [
     "index.js",
+    "install.js",
+    "resources",
     "README.md",
     "LICENSE.md",
     "SECURITY.md",

--- a/resources/agents/flux-ui-builder.md
+++ b/resources/agents/flux-ui-builder.md
@@ -1,0 +1,55 @@
+---
+name: flux-ui-builder
+description: Builds and revises Livewire Flux UI — Blade markup using <flux:*> components, forms, modals, tables, page layouts and icons. Use when a task involves creating or changing a Flux interface, picking the right Flux component, checking whether a component needs Flux Pro, or resolving Heroicon names. Resolves every Flux question through the flux-docs MCP server rather than from memory, so Flux documentation stays out of the main conversation.
+---
+
+# Flux UI Builder
+
+You build Livewire Flux interfaces. Your defining trait is that you **never guess Flux
+markup** — you look it up through the `flux-docs` MCP server, which reads fluxui.dev live.
+
+Tools are exposed by whichever key the MCP server was registered under (`flux-docs` by
+convention): `list_flux_components`, `fetch_flux_docs`, `list_flux_layouts`,
+`list_flux_component_icons`.
+
+## Method
+
+1. **Understand the surface.** Read the Blade/Livewire files you are being asked to change,
+   and match the Flux conventions already in the project.
+2. **Discover.** `list_flux_components` to confirm each component you plan to use exists and
+   to get its exact slug. For page-level chrome, `list_flux_layouts` first — do not hand-roll
+   a header or sidebar that Flux already ships.
+3. **Check the tier.** Results are annotated `[Free]` / `[Pro]`. If you need a `[Pro]`
+   component, confirm the project has Flux Pro (a `livewire/flux-pro` entry in
+   `composer.json`) before building on it. If it does not, choose a free alternative and say
+   what you swapped and why — do not silently ship markup that will not render.
+4. **Fetch the API.** `fetch_flux_docs` with `component` or `layout` for every component you
+   are about to write. The reference section carries the props, slots and variants. Pass
+   `version: 'v1'` if the project is on Flux v1 (no layouts, no Pro tier there).
+5. **Resolve icons.** `list_flux_component_icons` with a `search` term for the exact name.
+   Icon components are `<flux:icon.name />` with an optional
+   `variant="solid|mini|micro"`; components with an `icon` prop take the bare name.
+6. **Write the markup.** Prefer a Flux component over custom HTML whenever one exists.
+7. **Verify.** Confirm every component, prop and icon you used appears in what `flux-docs`
+   returned. Check interactive states and mobile layout where relevant.
+
+## Rules
+
+- If `flux-docs` is unreachable, stop and report it. Do not fall back to guessing — wrong
+  `<flux:*>` markup fails silently or renders as an unknown tag.
+- Do not trust a component list from any guideline, skill or memory. Call
+  `list_flux_components`.
+- Do not invent props or variants. If the reference section does not list it, it does not
+  exist.
+- Stay inside the UI. Leave Livewire component logic, routing and data access to the caller
+  unless explicitly asked.
+
+## Report back
+
+- The files you changed.
+- Every Flux component and icon used, and its tier.
+- Anything you swapped because it was Pro-gated or did not exist.
+- Anything you could not verify against `flux-docs`.
+
+<!-- livewire-flux-mcp:managed -->
+

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,26 @@
+## Flux UI Documentation Source
+
+This project has the `flux-docs` MCP server available (`livewire-flux-mcp`). It reads
+fluxui.dev on demand, so it reflects the components that exist today and knows which ones
+require a paid Flux Pro licence.
+
+- Resolve every Flux question through `flux-docs` before writing markup: `list_flux_components`
+  (what exists, and free vs Pro), `fetch_flux_docs` (props, slots, variants, layouts),
+  `list_flux_layouts`, `list_flux_component_icons` (exact icon names).
+- No component list written into a guideline or skill is authoritative — including any list
+  above or below this section. Lists go stale as Flux ships; call `list_flux_components`.
+- Check the tier before building. Using a Pro-only component in a free-edition project is the
+  most common Flux failure.
+- Never invent a `flux:` component, prop, variant or icon name. If `flux-docs` is
+  unreachable, say so rather than guessing.
+- Both Flux major versions are reachable: pass `version: 'v1'` for legacy projects. v1 has no
+  layouts and no Pro tier.
+
+Use the `fluxui-development` skill for the full workflow.
+
+@verbatim
+<code-snippet name="Confirm a component and its tier before using it" lang="text">
+list_flux_components  { "tier": "all" }        → e.g. "Date Picker [Pro] (date-picker)"
+fetch_flux_docs       { "component": "date-picker" }
+</code-snippet>
+@endverbatim

--- a/resources/boost/skills/fluxui-development/SKILL.md
+++ b/resources/boost/skills/fluxui-development/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: fluxui-development
+description: "Use this skill for Flux UI development in Livewire applications only. Trigger when working with <flux:*> components, building or customizing Livewire component UIs, creating forms, modals, tables, or other interactive elements. Covers: flux: components (buttons, inputs, modals, forms, tables, date-pickers, kanban, badges, tooltips, etc.), layouts, component composition, Tailwind CSS styling, Heroicons/Lucide icon integration, validation patterns, responsive design, and theming. Looks everything up live through the flux-docs MCP server instead of relying on a memorised component list. Do not use for non-Livewire frameworks or non-component styling."
+license: MIT
+---
+
+# Flux UI Development
+
+Flux UI is a component library for Livewire built with Tailwind CSS. Use Flux components
+when one exists. Fall back to standard Blade components only when no Flux component covers
+the need.
+
+## Documentation
+
+This project has the **`flux-docs` MCP server** available. It reads
+[fluxui.dev](https://fluxui.dev) on demand, so it always reflects the components that exist
+today and knows which ones are Pro-gated.
+
+**Look Flux things up with `flux-docs` first.** Do not answer from memory, and do not treat
+any component list written into a guideline or skill (including this one) as authoritative.
+
+| Question | Tool | Notes |
+| --- | --- | --- |
+| Which components exist? Is X free or Pro? | `list_flux_components` | `tier: 'free' \| 'pro' \| 'all'`, annotates each result `[Free]` / `[Pro]` |
+| What props/slots/variants does X take? | `fetch_flux_docs` | `component: 'button'` — returns the page plus its reference section |
+| Which layouts exist? | `list_flux_layouts` | v2 only |
+| How is layout X structured? | `fetch_flux_docs` | `layout: 'header'` |
+| What icons can I use, and what is the exact name? | `list_flux_component_icons` | `variant` and `search` filters |
+
+If `flux-docs` is unavailable, say so and stop — do not guess component or prop names.
+Boost's `search-docs` tool is a reasonable secondary source for prose and Livewire-side
+questions, but `flux-docs` is the authority on what a Flux component actually accepts.
+
+## Workflow
+
+1. **Discover** — `list_flux_components` to confirm the component exists and get its slug.
+2. **Check the tier** — if it comes back `[Pro]`, confirm the project has Flux Pro before
+   building on it. `fetch_flux_docs` also prepends a `[NOTICE] This is a Flux Pro
+   component` line for Pro pages.
+3. **Fetch the API** — `fetch_flux_docs` for the component or layout. Read the reference
+   section; that is where props, slots and variants live.
+4. **Resolve icons** — `list_flux_component_icons` with a `search` term. Never invent an
+   icon name.
+5. **Build** the Blade markup.
+6. **Verify** — component renders, interactive states work, layout holds on mobile.
+
+## Editions and the Pro tier
+
+A subset of Flux v2 components requires a paid Flux Pro licence. Rather than memorising
+which, call `list_flux_components`:
+
+- `tier: 'free'` — only components available without a licence.
+- `tier: 'pro'` — only the paid ones.
+- `tier: 'all'` (default) — everything, each annotated `[Free]` or `[Pro]`.
+
+Reaching for a Pro component in a free-edition project is the most common Flux failure.
+Check the tier before you build, not after the page breaks.
+
+## Versions
+
+`fetch_flux_docs`, `list_flux_components` and `list_flux_layouts` all accept
+`version: 'v1' | 'v2'`, defaulting to `'v2'`.
+
+- **v2** (default) — `fluxui.dev`. Components, layouts and the Pro tier.
+- **v1** — `v1.fluxui.dev`. Components only: v1 has no layouts route and no Pro tier, so
+  `list_flux_layouts` returns a notice and `tier` is ignored.
+
+Icons are version-independent.
+
+## Layouts
+
+Flux v2 ships page-level layouts (header, sidebar, and so on) alongside components. Use
+`list_flux_layouts` to see them and `fetch_flux_docs` with `layout: '<name>'` for the
+markup. Reach for a layout before hand-rolling page chrome.
+
+## Icons
+
+Flux uses [Heroicons](https://heroicons.com) as its default icon set. Get exact names from
+`list_flux_component_icons` — it returns the real names for each variant along with the
+correct syntax:
+
+```blade
+<flux:icon.arrow-down-tray />
+<flux:icon.arrow-down-tray variant="solid" />
+<flux:icon.arrow-down-tray variant="mini" />
+<flux:icon.arrow-down-tray variant="micro" />
+```
+
+Components that accept an `icon` prop take the bare name:
+
+```blade
+<flux:button icon="arrow-down-tray">Export</flux:button>
+```
+
+For icons Heroicons does not have, use [Lucide](https://lucide.dev) and import them:
+
+```bash
+php artisan flux:icon crown grip-vertical github
+```
+
+## Common patterns
+
+Confirm the current API with `fetch_flux_docs` before relying on these shapes.
+
+```blade
+<flux:button variant="primary">Click me</flux:button>
+```
+
+```blade
+<flux:field>
+    <flux:label>Email</flux:label>
+    <flux:input type="email" wire:model="email" />
+    <flux:error name="email" />
+</flux:field>
+```
+
+```blade
+<flux:modal wire:model="showModal">
+    <flux:heading>Title</flux:heading>
+    <p>Content</p>
+</flux:modal>
+```
+
+```blade
+<flux:table>
+    <flux:table.columns>
+        <flux:table.cell>Column Name</flux:table.cell>
+    </flux:table.columns>
+    <flux:table.row>
+        <flux:table.cell>Value</flux:table.cell>
+    </flux:table.row>
+</flux:table>
+```
+
+## Common pitfalls
+
+- Trusting a hardcoded component list. Lists in guidelines go stale as Flux ships new
+  components — `list_flux_components` does not.
+- Using a Pro component in a free-edition project. Check the tier first.
+- Inventing `<flux:*>` names, props or variants. If `fetch_flux_docs` does not show it, it
+  does not exist.
+- Guessing icon names instead of calling `list_flux_component_icons`.
+- Hand-rolling markup for something Flux already provides — check `list_flux_components`
+  and `list_flux_layouts` before writing custom HTML.
+- Ignoring the project's existing Flux conventions.
+
+## Attribution
+
+Portions of this skill are adapted from the `fluxui-development` skill in
+[laravel/boost](https://github.com/laravel/boost), MIT © Taylor Otwell. It is installed by
+[livewire-flux-mcp](https://github.com/leMaur/livewire-flux-mcp) and deliberately replaces
+the bundled version so that Flux lookups go through the live documentation server.
+
+<!-- livewire-flux-mcp:managed -->
+

--- a/test/unit/install.test.js
+++ b/test/unit/install.test.js
@@ -1,0 +1,425 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseInstallArgs,
+  detectFluxEdition,
+  findVendorGuideline,
+  composeGuideline,
+  planInstall,
+  runInstall,
+  GUIDELINE_MARKER_BEGIN,
+  GUIDELINE_MARKER_END,
+  MANAGED_MARKER,
+} from '../../install.js';
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const SKILL_DEST = join('.ai', 'skills', 'fluxui-development', 'SKILL.md');
+const PRO_GUIDELINE_DEST = join('.ai', 'guidelines', 'fluxui-pro', 'core.blade.php');
+const FREE_GUIDELINE_DEST = join('.ai', 'guidelines', 'fluxui-free', 'core.blade.php');
+const AGENT_DEST = join('.claude', 'agents', 'flux-ui-builder.md');
+
+let projectDir;
+const silent = () => {};
+
+function write(relPath, contents) {
+  const full = join(projectDir, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, contents, 'utf-8');
+  return full;
+}
+
+function read(relPath) {
+  return readFileSync(join(projectDir, relPath), 'utf-8');
+}
+
+function composerWith(packages) {
+  return JSON.stringify({ require: packages }, null, 2);
+}
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), 'flux-mcp-install-'));
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe('shipped artifacts', () => {
+  // The override is keyed on the frontmatter `name`. If this string ever drifts, Boost's
+  // bundled fluxui-development skill silently wins again and the MCP server is bypassed.
+  test('skill frontmatter name is exactly fluxui-development', () => {
+    const skill = readFileSync(
+      join(PACKAGE_ROOT, 'resources', 'boost', 'skills', 'fluxui-development', 'SKILL.md'),
+      'utf-8'
+    );
+
+    const frontmatter = skill.match(/^---\n([\s\S]*?)\n---/);
+    assert.ok(frontmatter, 'SKILL.md must start with YAML frontmatter');
+
+    const name = frontmatter[1].match(/^name:\s*(.+)$/m);
+    assert.ok(name, 'frontmatter must declare a name');
+    assert.strictEqual(name[1].trim(), 'fluxui-development');
+  });
+
+  test('skill and subagent carry the managed marker', () => {
+    for (const relPath of [
+      join('resources', 'boost', 'skills', 'fluxui-development', 'SKILL.md'),
+      join('resources', 'agents', 'flux-ui-builder.md'),
+    ]) {
+      const contents = readFileSync(join(PACKAGE_ROOT, relPath), 'utf-8');
+      assert.ok(contents.includes(MANAGED_MARKER), `${relPath} must include the managed marker`);
+    }
+  });
+
+  test('subagent declares Claude Code frontmatter', () => {
+    const agent = readFileSync(join(PACKAGE_ROOT, 'resources', 'agents', 'flux-ui-builder.md'), 'utf-8');
+    const frontmatter = agent.match(/^---\n([\s\S]*?)\n---/);
+
+    assert.ok(frontmatter, 'subagent must start with YAML frontmatter');
+    assert.match(frontmatter[1], /^name:\s*flux-ui-builder$/m);
+    assert.match(frontmatter[1], /^description:\s*\S/m);
+  });
+});
+
+describe('parseInstallArgs', () => {
+  test('reads flags and both --path forms', () => {
+    assert.deepStrictEqual(parseInstallArgs(['--path', '/tmp/x', '--dry-run', '--force']), {
+      path: '/tmp/x',
+      boost: false,
+      claude: false,
+      dryRun: true,
+      force: true,
+      help: false,
+      unknown: [],
+      errors: [],
+    });
+
+    assert.strictEqual(parseInstallArgs(['--path=/tmp/y']).path, '/tmp/y');
+    assert.strictEqual(parseInstallArgs(['--boost']).boost, true);
+    assert.strictEqual(parseInstallArgs(['--claude']).claude, true);
+    assert.strictEqual(parseInstallArgs(['-h']).help, true);
+  });
+
+  test('collects unknown options instead of throwing', () => {
+    assert.deepStrictEqual(parseInstallArgs(['--nope']).unknown, ['--nope']);
+  });
+
+  // Without this guard `--path --dry-run` installs for real into a directory named
+  // "--dry-run", which is the worst possible reading of a dry run.
+  test('refuses to let --path swallow the following flag', () => {
+    const swallowed = parseInstallArgs(['--path', '--dry-run']);
+
+    assert.strictEqual(swallowed.path, null);
+    assert.strictEqual(swallowed.dryRun, true);
+    assert.strictEqual(swallowed.errors.length, 1);
+
+    assert.strictEqual(parseInstallArgs(['--path']).errors.length, 1);
+    assert.strictEqual(parseInstallArgs(['--path=']).errors.length, 1);
+  });
+});
+
+describe('detectFluxEdition', () => {
+  test('maps livewire/flux-pro to fluxui-pro', () => {
+    write('composer.json', composerWith({ 'livewire/flux-pro': '^2.0' }));
+    assert.strictEqual(detectFluxEdition(projectDir), 'fluxui-pro');
+  });
+
+  test('maps livewire/flux to fluxui-free', () => {
+    write('composer.json', composerWith({ 'livewire/flux': '^2.0' }));
+    assert.strictEqual(detectFluxEdition(projectDir), 'fluxui-free');
+  });
+
+  test('prefers pro when both are required, matching Boost precedence', () => {
+    write('composer.json', composerWith({ 'livewire/flux': '^2.0', 'livewire/flux-pro': '^2.0' }));
+    assert.strictEqual(detectFluxEdition(projectDir), 'fluxui-pro');
+  });
+
+  test('finds packages declared in require-dev', () => {
+    write('composer.json', JSON.stringify({ 'require-dev': { 'livewire/flux': '^2.0' } }));
+    assert.strictEqual(detectFluxEdition(projectDir), 'fluxui-free');
+  });
+
+  test('returns null with no composer.json, no flux, or unreadable json', () => {
+    assert.strictEqual(detectFluxEdition(projectDir), null);
+
+    write('composer.json', composerWith({ 'laravel/framework': '^13.0' }));
+    assert.strictEqual(detectFluxEdition(projectDir), null);
+
+    write('composer.json', '{ not json');
+    assert.strictEqual(detectFluxEdition(projectDir), null);
+  });
+});
+
+describe('findVendorGuideline', () => {
+  test('finds the blade guideline shipped inside the flux package', () => {
+    write(join('vendor', 'livewire', 'flux-pro', 'resources', 'boost', 'guidelines', 'core.blade.php'), 'FLUX OWN');
+    const found = findVendorGuideline(projectDir, 'fluxui-pro');
+
+    assert.ok(found);
+    assert.strictEqual(found.content, 'FLUX OWN');
+  });
+
+  test('falls back to the markdown extension', () => {
+    write(join('vendor', 'livewire', 'flux', 'resources', 'boost', 'guidelines', 'core.md'), 'FREE OWN');
+    assert.strictEqual(findVendorGuideline(projectDir, 'fluxui-free').content, 'FREE OWN');
+  });
+
+  test('returns null when the package ships none', () => {
+    assert.strictEqual(findVendorGuideline(projectDir, 'fluxui-pro'), null);
+  });
+});
+
+describe('composeGuideline', () => {
+  test('wraps our block in markers', () => {
+    const result = composeGuideline('OUR BLOCK');
+
+    assert.ok(result.startsWith(GUIDELINE_MARKER_BEGIN));
+    assert.ok(result.includes('OUR BLOCK'));
+    assert.ok(result.includes(GUIDELINE_MARKER_END));
+  });
+
+  test('keeps existing content below our block', () => {
+    const result = composeGuideline('OUR BLOCK', 'THEIR CONTENT');
+
+    assert.ok(result.includes('THEIR CONTENT'));
+    assert.ok(result.indexOf('OUR BLOCK') < result.indexOf('THEIR CONTENT'));
+  });
+
+  test('replaces a previous block rather than stacking them', () => {
+    const first = composeGuideline('BLOCK V1', 'THEIR CONTENT');
+    const second = composeGuideline('BLOCK V2', first);
+
+    assert.ok(!second.includes('BLOCK V1'));
+    assert.ok(second.includes('BLOCK V2'));
+    assert.ok(second.includes('THEIR CONTENT'));
+    assert.strictEqual(second.split(GUIDELINE_MARKER_BEGIN).length - 1, 1);
+  });
+
+  test('is idempotent', () => {
+    const once = composeGuideline('OUR BLOCK', 'THEIR CONTENT');
+    assert.strictEqual(composeGuideline('OUR BLOCK', once), once);
+  });
+
+  test('replaces the block in place, preserving surrounding bytes exactly', () => {
+    const existing = `ABOVE\n\n${GUIDELINE_MARKER_BEGIN}\nOLD\n${GUIDELINE_MARKER_END}\n\nBELOW\n`;
+    const result = composeGuideline('NEW', existing);
+
+    assert.ok(result.startsWith('ABOVE\n\n'), 'content above the block must keep its position');
+    assert.ok(result.endsWith('\n\nBELOW\n'), 'content below the block must keep its trailing bytes');
+    assert.ok(result.includes('NEW'));
+    assert.ok(!result.includes('OLD'));
+  });
+
+  // Ambiguous markers mean we cannot tell which span is ours — deleting the wrong one
+  // would silently destroy user content.
+  test('refuses malformed, duplicated or out-of-order markers', () => {
+    const duplicated = `${GUIDELINE_MARKER_BEGIN}\nA\n${GUIDELINE_MARKER_END}\n${GUIDELINE_MARKER_BEGIN}\nB\n${GUIDELINE_MARKER_END}`;
+    const partial = `${GUIDELINE_MARKER_BEGIN}\nA\n`;
+    const reversed = `${GUIDELINE_MARKER_END}\nA\n${GUIDELINE_MARKER_BEGIN}`;
+
+    for (const broken of [duplicated, partial, reversed]) {
+      assert.throws(() => composeGuideline('NEW', broken), /malformed/);
+    }
+  });
+
+  test('--force resolves malformed markers by replacing the whole span', () => {
+    const duplicated = `${GUIDELINE_MARKER_BEGIN}\nA\n${GUIDELINE_MARKER_END}\n${GUIDELINE_MARKER_BEGIN}\nB\n${GUIDELINE_MARKER_END}`;
+    const result = composeGuideline('NEW', duplicated, { force: true });
+
+    assert.strictEqual(result.split(GUIDELINE_MARKER_BEGIN).length - 1, 1);
+    assert.ok(!result.includes('\nA\n') && !result.includes('\nB\n'));
+  });
+});
+
+describe('planInstall target selection', () => {
+  test('composer.json alone selects boost only', () => {
+    write('composer.json', composerWith({ 'livewire/flux': '^2.0' }));
+    const plan = planInstall({ path: projectDir });
+
+    assert.strictEqual(plan.boost, true);
+    assert.strictEqual(plan.claude, false);
+  });
+
+  test('.claude/ alone selects the subagent too', () => {
+    mkdirSync(join(projectDir, '.claude'), { recursive: true });
+    const plan = planInstall({ path: projectDir });
+
+    assert.strictEqual(plan.claude, true);
+  });
+
+  test('explicit --claude suppresses boost autodetection', () => {
+    write('composer.json', composerWith({ 'livewire/flux': '^2.0' }));
+    const plan = planInstall({ path: projectDir, claude: true });
+
+    assert.strictEqual(plan.boost, false);
+    assert.strictEqual(plan.claude, true);
+  });
+
+  test('an unrecognised directory still gets the boost artifacts', () => {
+    const plan = planInstall({ path: projectDir });
+    assert.strictEqual(plan.boost, true);
+  });
+});
+
+describe('runInstall', () => {
+  test('installs skill and pro guideline for a flux-pro project', () => {
+    write('composer.json', composerWith({ 'livewire/flux-pro': '^2.0' }));
+
+    const code = runInstall(['--path', projectDir], { log: silent });
+
+    assert.strictEqual(code, 0);
+    assert.ok(existsSync(join(projectDir, SKILL_DEST)));
+    assert.ok(existsSync(join(projectDir, PRO_GUIDELINE_DEST)));
+    assert.ok(!existsSync(join(projectDir, FREE_GUIDELINE_DEST)));
+    assert.match(read(SKILL_DEST), /^name:\s*fluxui-development$/m);
+  });
+
+  test('writes both guideline keys when the edition is unknown', () => {
+    runInstall(['--path', projectDir], { log: silent });
+
+    assert.ok(existsSync(join(projectDir, PRO_GUIDELINE_DEST)));
+    assert.ok(existsSync(join(projectDir, FREE_GUIDELINE_DEST)));
+  });
+
+  test("preserves the flux package's own guideline below our block", () => {
+    write('composer.json', composerWith({ 'livewire/flux-pro': '^2.0' }));
+    write(
+      join('vendor', 'livewire', 'flux-pro', 'resources', 'boost', 'guidelines', 'core.blade.php'),
+      '## Flux\n\nOfficial Flux guidance that must survive.'
+    );
+
+    runInstall(['--path', projectDir], { log: silent });
+    const guideline = read(PRO_GUIDELINE_DEST);
+
+    assert.ok(guideline.includes('Official Flux guidance that must survive.'));
+    assert.ok(guideline.indexOf(GUIDELINE_MARKER_BEGIN) < guideline.indexOf('Official Flux guidance'));
+  });
+
+  test("preserves a user's pre-existing guideline instead of clobbering it", () => {
+    write('composer.json', composerWith({ 'livewire/flux-pro': '^2.0' }));
+    write(PRO_GUIDELINE_DEST, '## House rules\n\nAlways use Flux components.');
+
+    const code = runInstall(['--path', projectDir], { log: silent });
+
+    assert.strictEqual(code, 0);
+    assert.ok(read(PRO_GUIDELINE_DEST).includes('Always use Flux components.'));
+  });
+
+  test('is idempotent — a second run changes nothing', () => {
+    write('composer.json', composerWith({ 'livewire/flux-pro': '^2.0' }));
+    write(
+      join('vendor', 'livewire', 'flux-pro', 'resources', 'boost', 'guidelines', 'core.blade.php'),
+      'VENDOR CONTENT'
+    );
+    mkdirSync(join(projectDir, '.claude'), { recursive: true });
+
+    runInstall(['--path', projectDir], { log: silent });
+    const first = [SKILL_DEST, PRO_GUIDELINE_DEST, AGENT_DEST].map(read);
+
+    const code = runInstall(['--path', projectDir], { log: silent });
+    const second = [SKILL_DEST, PRO_GUIDELINE_DEST, AGENT_DEST].map(read);
+
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(second, first);
+    assert.strictEqual(second[1].split(GUIDELINE_MARKER_BEGIN).length - 1, 1);
+  });
+
+  test('installs the subagent when .claude/ exists', () => {
+    mkdirSync(join(projectDir, '.claude'), { recursive: true });
+
+    runInstall(['--path', projectDir, '--claude'], { log: silent });
+
+    assert.ok(existsSync(join(projectDir, AGENT_DEST)));
+    assert.match(read(AGENT_DEST), /^name:\s*flux-ui-builder$/m);
+  });
+
+  test('--dry-run writes nothing', () => {
+    write('composer.json', composerWith({ 'livewire/flux': '^2.0' }));
+
+    const code = runInstall(['--path', projectDir, '--dry-run'], { log: silent });
+
+    assert.strictEqual(code, 0);
+    assert.ok(!existsSync(join(projectDir, SKILL_DEST)));
+    assert.ok(!existsSync(join(projectDir, FREE_GUIDELINE_DEST)));
+  });
+
+  test('refuses to replace an unmanaged skill, and --force overrides', () => {
+    write('composer.json', composerWith({ 'livewire/flux': '^2.0' }));
+    write(SKILL_DEST, '---\nname: fluxui-development\n---\n\nMy own skill.');
+
+    const refused = runInstall(['--path', projectDir], { log: silent });
+
+    assert.strictEqual(refused, 1);
+    assert.strictEqual(read(SKILL_DEST), '---\nname: fluxui-development\n---\n\nMy own skill.');
+
+    const forced = runInstall(['--path', projectDir, '--force'], { log: silent });
+
+    assert.strictEqual(forced, 0);
+    assert.ok(read(SKILL_DEST).includes(MANAGED_MARKER));
+  });
+
+  // A half-installed project is worse than an uninstalled one: if any step is refused,
+  // nothing at all should land.
+  test('a single refusal prevents every other write', () => {
+    write('composer.json', composerWith({ 'livewire/flux': '^2.0' }));
+    write(SKILL_DEST, 'My own skill.');
+
+    const code = runInstall(['--path', projectDir], { log: silent });
+
+    assert.strictEqual(code, 1);
+    assert.ok(!existsSync(join(projectDir, FREE_GUIDELINE_DEST)), 'guideline must not be written');
+  });
+
+  test('a quoted managed marker in prose does not transfer ownership', () => {
+    write('composer.json', composerWith({ 'livewire/flux': '^2.0' }));
+    write(SKILL_DEST, 'Docs mentioning `<!-- livewire-flux-mcp:managed -->` inline. Still mine.');
+
+    assert.strictEqual(runInstall(['--path', projectDir], { log: silent }), 1);
+    assert.ok(read(SKILL_DEST).includes('Still mine.'));
+  });
+
+  test('refuses a destination that symlinks outside the project', () => {
+    const outside = mkdtempSync(join(tmpdir(), 'flux-mcp-outside-'));
+    try {
+      write('composer.json', composerWith({ 'livewire/flux': '^2.0' }));
+      symlinkSync(outside, join(projectDir, '.ai'), 'dir');
+
+      const code = runInstall(['--path', projectDir], { log: silent });
+
+      assert.strictEqual(code, 1);
+      assert.ok(!existsSync(join(outside, 'skills')), 'must not write through the symlink');
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects a --path that is not an existing directory', () => {
+    const file = write('not-a-dir.txt', 'x');
+
+    assert.strictEqual(runInstall(['--path', file], { log: silent }), 1);
+    assert.strictEqual(runInstall(['--path', join(projectDir, 'nope')], { log: silent }), 1);
+  });
+
+  test('reports unknown options with a non-zero exit code', () => {
+    assert.strictEqual(runInstall(['--wat'], { log: silent }), 1);
+    assert.strictEqual(runInstall(['--wat', '--help'], { log: silent }), 1);
+  });
+
+  test('--path with a missing value fails instead of installing into cwd', () => {
+    assert.strictEqual(runInstall(['--path'], { log: silent }), 1);
+    assert.strictEqual(runInstall(['--path', '--dry-run'], { log: silent }), 1);
+  });
+
+  test('--help prints usage without writing', () => {
+    const lines = [];
+    const code = runInstall(['--help'], { log: (line) => lines.push(line) });
+
+    assert.strictEqual(code, 0);
+    assert.match(lines.join('\n'), /Usage:/);
+  });
+});


### PR DESCRIPTION
> Stacked on `docs/agent-setup-instructions`. Review that one first; this PR's diff is scoped against it. Base retargets to `main` automatically when it merges.

## Problem

Registering the server tells an agent the tools *exist*. It does not tell it when to reach for them — and in a Laravel Boost project it actively steers away from them. Boost bundles a `fluxui-development` skill whose Documentation section reads:

> Use `search-docs` for detailed Flux UI patterns and documentation.

and whose `## Available Components` section is a hardcoded list. An agent follows that skill and never calls this server.

## Why an installer rather than package discovery

Boost only auto-discovers third-party guidelines and skills from **Composer** packages: `Composer::packages()` reads `composer.json`, then looks under `vendor/{pkg}/resources/boost/…`. The npm equivalent exists but is gated on a fixed first-party allowlist (`@inertiajs`, `@laravel`, `laravel-echo`, `laravel-precognition`, `laravel-vite-plugin`), so an npm package cannot opt in.

So the artifacts ship in the package and an installer writes them into the paths Boost documents for *custom* guidelines and skills, which take precedence over the bundled ones and survive `boost:update`.

```shell
npx livewire-flux-mcp install
```

## What it installs

| Path | Notes |
| --- | --- |
| `.ai/skills/fluxui-development/SKILL.md` | Replaces the bundled skill. The frontmatter `name` **is** the override key, so it must match exactly — a test asserts it. |
| `.ai/guidelines/fluxui-{free,pro}/core.blade.php` | Key selected from `composer.json`: `livewire/flux-pro` → `fluxui-pro`, `livewire/flux` → `fluxui-free`, matching Boost's own precedence. Both written when neither is present. |
| `.claude/agents/flux-ui-builder.md` | Subagent that looks each component up before writing markup. |

The replacement skill resolves components through the MCP tools instead of a static list, so it cannot go stale, and it covers layouts, v1 and the Pro tier — none of which the bundled skill mentions. Portions adapted from `laravel/boost` (MIT), attributed in the file.

## Safety

- **The guideline is merged, never clobbered.** Flux ships its own core guideline inside its Composer package, so a blind override would silently delete it. An existing file at the destination, or that vendor file, is preserved below a delimited block; re-runs refresh only the block.
- Ambiguous markers (partial, duplicated, out of order) are refused rather than guessed at.
- Whole-file artifacts carry a managed marker; a file the installer did not write is refused unless `--force`.
- **A refusal aborts before anything is written**, so a run never leaves a half-installed project.
- Destinations resolving outside the project (via a symlinked `.ai` or `.claude`) are rejected.
- `--path` will not swallow a following flag, so `--path --dry-run` fails instead of installing into a directory named `--dry-run`.

## Server safety

The subcommand is guarded on `argv[2] === 'install'` and the module is imported lazily, so a bare invocation still starts a stdio server with **zero bytes on stdout**. Any other argument starts the server rather than erroring, so an unexpected argument from a client cannot break it.

## Verification

40 tests covering the override key, edition detection (including pro-wins-over-free and `require-dev`), merge preservation, idempotency, `--dry-run`, refusal handling, marker validation and path containment. Suite green; `npm pack --dry-run` confirms `resources/**` and `install.js` ship.

End to end against a scratch project with a `livewire/flux-pro` requirement and a vendor guideline: correct edition detected, vendor content preserved below the block, second run a byte-identical no-op.

## Notes

No version bump — the publish workflow derives the version from the release tag.
